### PR TITLE
Drop python2 support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.6
+current_version = 3.0.7
 commit = True
 tag = True
 

--- a/pytest_testrail/TestrailModel.py
+++ b/pytest_testrail/TestrailModel.py
@@ -1,38 +1,41 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
 class TestRailModel:
     assign_user_id: int
-    user_email: str = None
-    user_password: str = None
-    tr_url: str = None
+    user_email: str | None = None
+    user_password: str | None = None
+    tr_url: str | None = None
     cert_check: bool = False
-    client: any = None
-    project_id: int = None
-    results: list = None
-    suite_id: int = None
-    include_all: bool = None
-    testrun_name: str = None
-    testrun_description: str = None
-    testrun_id: int = None
-    testplan_entry_id: str = None
-    testplan_id: int = None
-    testplan_name: int = None
-    testplan_description: str = None
-    version: str = None
-    close_on_complete: bool = None
-    publish_blocked: bool = None
-    skip_missing: bool = None
-    milestone_id: int = None
-    custom_comment: str = None
+    client: Any = None
+    project_id: int | None = None
+    results: list = field(default_factory=list)
+    suite_id: int | None = None
+    include_all: bool | None = None
+    testrun_name: str | None = None
+    testrun_description: str | None = None
+    testrun_id: int | None = None
+    testplan_entry_id: str | None = None
+    testplan_id: int | None = None
+    testplan_name: str | None = None
+    testplan_description: str | None = None
+    version: str | None = None
+    close_on_complete: bool | None = None
+    publish_blocked: bool | None = None
+    skip_missing: bool | None = None
+    milestone_id: int | None = None
+    custom_comment: str | None = None
     test_run_flag: bool = False
-    tr_keys: list = None
-    actual_suites_with_case_ids: dict = None
-    plan_entry_storage: dict = None
-    diff_case_ids: list = None
-    available_suite_ids: dict = None
-    test_comments: list = field(default_factory=[])
+    tr_keys: list = field(default_factory=list)
+    actual_suites_with_case_ids: dict = field(default_factory=dict)
+    plan_entry_storage: dict = field(default_factory=dict)
+    diff_case_ids: list = field(default_factory=list)
+    available_suite_ids: dict = field(default_factory=dict)
+    test_comments: list = field(default_factory=list)
 
 
 @dataclass()

--- a/pytest_testrail/__init__.py
+++ b/pytest_testrail/__init__.py
@@ -1,3 +1,2 @@
 # -*- coding: UTF-8 -*-
 from pytest_testrail.functions import pytestrail as pytestrail, testrail as testrail
-

--- a/pytest_testrail/__init__.py
+++ b/pytest_testrail/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: UTF-8 -*-
-from pytest_testrail.functions import pytestrail, testrail
+from pytest_testrail.functions import pytestrail as pytestrail, testrail as testrail
 

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -220,9 +220,9 @@ def pytest_configure(config):
         cfg_file_path = config.getoption("--tr-config")
         config_manager = ConfigManager(cfg_file_path, config)
         client = APIClient(
-            config_manager.getoption("tr-url", "url", "API"),
-            config_manager.getoption("tr-email", "email", "API"),
-            config_manager.getoption("tr-password", "password", "API"),
+            str(config_manager.getoption("tr-url", "url", "API") or ""),
+            str(config_manager.getoption("tr-email", "email", "API") or ""),
+            str(config_manager.getoption("tr-password", "password", "API") or ""),
             timeout=config_manager.getoption("tr-timeout", "timeout", "API"),
         )
 
@@ -258,8 +258,11 @@ def pytest_configure(config):
                     default=True,
                 ),
                 tr_name=config_manager.getoption("tr-testrun-name", "name", "TESTRUN"),
-                tr_description=config_manager.getoption(
-                    "tr-testrun-description", "description", "TESTRUN"
+                tr_description=str(
+                    config_manager.getoption(
+                        "tr-testrun-description", "description", "TESTRUN"
+                    )
+                    or ""
                 ),
                 testplan_name=config_manager.getoption(
                     "tr-testplan-name", "name", "TESTRUN"
@@ -268,7 +271,9 @@ def pytest_configure(config):
                     "tr-testplan-description", "description", "TESTRUN"
                 ),
                 run_id=config.getoption("--tr-run-id"),
-                plan_id=config_manager.getoption("tr-plan-id", "plan_id", "TESTRUN"),
+                plan_id=int(
+                    config_manager.getoption("tr-plan-id", "plan_id", "TESTRUN") or 0
+                ),
                 version=config.getoption("--tr-version"),
                 close_on_complete=config.getoption("--tr-close-on-complete"),
                 publish_blocked=config.getoption("--tr-dont-publish-blocked"),

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -1,15 +1,8 @@
 # -*- coding: UTF-8 -*-
 import os
-import sys
+import configparser
 from .plugin import PyTestRailPlugin
 from .testrail_api import APIClient
-
-if sys.version_info.major == 2:
-    # python2
-    import ConfigParser as configparser
-else:
-    # python3
-    import configparser
 
 
 class Messages:

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -6,168 +6,288 @@ from .testrail_api import APIClient
 
 
 class Messages:
-    TESTRAIL = 'Create and update testruns with TestRail'
-    TR_CONFIG = 'Path to the config file containing information about the TestRail server (defaults to testrail.cfg)'
-    TR_URL = 'TestRail address you use to access TestRail with your web browser (config file: url in API section)'
-    TR_EMAIL = 'Email for the account on the TestRail server (config file: email in API section)'
-    TR_PASSWORD = 'Password for the account on the TestRail server (config file: password in API section)'
-    TR_TIMEOUT = 'Set timeout for connecting to TestRail server'
-    TR_TESTRUN_ASSIGNED_TO = 'ID of the user assigned to the test run (config file: assignedto_id in TESTRUN section)'
-    TR_TESTRUN_PROJECT_ID = 'ID of the project the test run is in (config file: project_id in TESTRUN section)'
-    TR_TESTRUN_SUITE_ID = 'ID of the test suite containing the test cases (config file: suite_id in TESTRUN section)'
-    TR_TESTRUN_SUITE_INCLUDE_ALL = 'Include all test cases in specified test suite when creating test run config file: include_all in TESTRUN section)'
-    TR_TESTRUN_NAME = 'Name given to testrun, that appears in TestRail (config file: name in TESTRUN section)'
-    TR_TESTRUN_DESCRIPTION = 'Description given to testrun, that appears in TestRail config file: description in TESTRUN section'
+    TESTRAIL = "Create and update testruns with TestRail"
+    TR_CONFIG = "Path to the config file containing information about the TestRail server (defaults to testrail.cfg)"
+    TR_URL = "TestRail address you use to access TestRail with your web browser (config file: url in API section)"
+    TR_EMAIL = "Email for the account on the TestRail server (config file: email in API section)"
+    TR_PASSWORD = "Password for the account on the TestRail server (config file: password in API section)"
+    TR_TIMEOUT = "Set timeout for connecting to TestRail server"
+    TR_TESTRUN_ASSIGNED_TO = "ID of the user assigned to the test run (config file: assignedto_id in TESTRUN section)"
+    TR_TESTRUN_PROJECT_ID = "ID of the project the test run is in (config file: project_id in TESTRUN section)"
+    TR_TESTRUN_SUITE_ID = "ID of the test suite containing the test cases (config file: suite_id in TESTRUN section)"
+    TR_TESTRUN_SUITE_INCLUDE_ALL = "Include all test cases in specified test suite when creating test run config file: include_all in TESTRUN section)"
+    TR_TESTRUN_NAME = "Name given to testrun, that appears in TestRail (config file: name in TESTRUN section)"
+    TR_TESTRUN_DESCRIPTION = "Description given to testrun, that appears in TestRail config file: description in TESTRUN section"
     TR_RUN_ID = 'Identifier of testrun, that appears in TestRail. If provided, option "--tr-testrun-name" will be ignored'
     TR_TEST_PLAN_ID = 'Identifier of testplan, that appears in TestRail (config file: plan_id in TESTRUN section). If provided, option "--tr-testrun-name" will be ignored'
-    TR_TEST_PLAN_NAME = 'Name given to testplan, that appears in TestRail (config file: name in TESTRUN section)'
-    TR_TEST_PLAN_DESCRIPTION = 'Description given to testplan, that appears in TestRail (config file: name in TESTRUN section)'
-    TR_TEST_PLAN_DESCRIPTION_DEFAULT = 'Test Plan was created via AutoTest'
-    TR_VERSION = 'Indicate a version in Test Case result'
-    TR_NO_SSL_CHECK = 'Do not check for valid SSL certificate on TestRail host'
-    TR_CLOSE_ON_COMPLETE = 'Close a test run on completion'
-    TR_DONT_PUBLISH_BLOCKED = 'Determine if results of "blocked" testcases (in TestRail) are published or not'
-    TR_SKIP_MISSING = 'Skip test cases that are not present in testrun'
-    TR_MILESTONE_ID = 'Identifier of milestone, to be used in run creation (config file: milestone_id in TESTRUN section)'
-    TC_CUSTOM_COMMENT = 'Custom comment, to be appended to default comment for test case (config file: custom_comment in TESTCASE section)'
+    TR_TEST_PLAN_NAME = "Name given to testplan, that appears in TestRail (config file: name in TESTRUN section)"
+    TR_TEST_PLAN_DESCRIPTION = "Description given to testplan, that appears in TestRail (config file: name in TESTRUN section)"
+    TR_TEST_PLAN_DESCRIPTION_DEFAULT = "Test Plan was created via AutoTest"
+    TR_VERSION = "Indicate a version in Test Case result"
+    TR_NO_SSL_CHECK = "Do not check for valid SSL certificate on TestRail host"
+    TR_CLOSE_ON_COMPLETE = "Close a test run on completion"
+    TR_DONT_PUBLISH_BLOCKED = (
+        'Determine if results of "blocked" testcases (in TestRail) are published or not'
+    )
+    TR_SKIP_MISSING = "Skip test cases that are not present in testrun"
+    TR_MILESTONE_ID = "Identifier of milestone, to be used in run creation (config file: milestone_id in TESTRUN section)"
+    TC_CUSTOM_COMMENT = "Custom comment, to be appended to default comment for test case (config file: custom_comment in TESTCASE section)"
 
 
 def pytest_addoption(parser):
-    group = parser.getgroup('testrail')
-    group.addoption('--testrail', action='store_true', help=Messages.TESTRAIL)
-    parser.addini("testrail", help=Messages.TESTRAIL, type='bool', default=None)
-
-    group.addoption('--tr-config', action='store', default='testrail.cfg', help=Messages.TR_CONFIG)
-    parser.addini('tr-config', help=Messages.TR_CONFIG, default='testrail.cfg')
-
-    group.addoption('--tr-url', action='store', help=Messages.TR_URL)
-    parser.addini('tr-url', help=Messages.TR_URL, default=None)
-
-    group.addoption('--tr-email', action='store', help=Messages.TR_EMAIL)
-    parser.addini('tr-email', help=Messages.TR_EMAIL, default=None)
-
-    group.addoption('--tr-password', action='store', help=Messages.TR_PASSWORD)
-    parser.addini('tr-password', help=Messages.TR_PASSWORD, default=None)
-
-    group.addoption('--tr-timeout', action='store', help=Messages.TR_TIMEOUT)
-    parser.addini('tr-timeout', help=Messages.TR_TIMEOUT, default=None)
-
-    group.addoption('--tr-testrun-assignedto-id', action='store', help=Messages.TR_TESTRUN_ASSIGNED_TO)
-    parser.addini('tr-testrun-assignedto-id', help=Messages.TR_TESTRUN_ASSIGNED_TO, default=None)
-
-    group.addoption('--tr-testrun-project-id', action='store', help=Messages.TR_TESTRUN_PROJECT_ID)
-    parser.addini('tr-testrun-project-id', help=Messages.TR_TESTRUN_PROJECT_ID, default=None)
-
-    group.addoption('--tr-testrun-suite-id', action='store', help=Messages.TR_TESTRUN_SUITE_ID)
-    parser.addini('tr-testrun-suite-id', help=Messages.TR_TESTRUN_SUITE_ID, default=None)
+    group = parser.getgroup("testrail")
+    group.addoption("--testrail", action="store_true", help=Messages.TESTRAIL)
+    parser.addini("testrail", help=Messages.TESTRAIL, type="bool", default=None)
 
     group.addoption(
-        '--tr-testrun-suite-include-all', action='store_true', default=False, help=Messages.TR_TESTRUN_SUITE_INCLUDE_ALL
+        "--tr-config", action="store", default="testrail.cfg", help=Messages.TR_CONFIG
     )
-    parser.addini('tr-testrun-suite-include-all', help=Messages.TR_TESTRUN_SUITE_INCLUDE_ALL, default=False)
+    parser.addini("tr-config", help=Messages.TR_CONFIG, default="testrail.cfg")
 
-    group.addoption('--tr-testrun-name', action='store', default=None, help=Messages.TR_TESTRUN_NAME)
-    parser.addini('tr-testrun-name', help=Messages.TR_TESTRUN_NAME, default=None)
+    group.addoption("--tr-url", action="store", help=Messages.TR_URL)
+    parser.addini("tr-url", help=Messages.TR_URL, default=None)
 
-    group.addoption('--tr-testrun-description', action='store', default=None, help=Messages.TR_TESTRUN_DESCRIPTION)
-    parser.addini('tr-testrun-description', help=Messages.TR_TESTRUN_DESCRIPTION, default=None)
+    group.addoption("--tr-email", action="store", help=Messages.TR_EMAIL)
+    parser.addini("tr-email", help=Messages.TR_EMAIL, default=None)
 
-    group.addoption('--tr-run-id', action='store', default=0, required=False, help=Messages.TR_RUN_ID)
-    parser.addini('tr-run-id', help=Messages.TR_RUN_ID, default=0)
+    group.addoption("--tr-password", action="store", help=Messages.TR_PASSWORD)
+    parser.addini("tr-password", help=Messages.TR_PASSWORD, default=None)
 
-    group.addoption('--tr-plan-id', action='store', required=False, help=Messages.TR_TEST_PLAN_ID)
-    parser.addini('tr-plan-id', help=Messages.TR_TEST_PLAN_ID, default=None)
-
-    group.addoption('--tr-testplan-name', action='store', default=None, help=Messages.TR_TEST_PLAN_NAME)
-    parser.addini('tr-testplan-name', help=Messages.TR_TEST_PLAN_NAME, default=None)
+    group.addoption("--tr-timeout", action="store", help=Messages.TR_TIMEOUT)
+    parser.addini("tr-timeout", help=Messages.TR_TIMEOUT, default=None)
 
     group.addoption(
-        '--tr-testplan-description',
-        action='store',
-        default=Messages.TR_TEST_PLAN_DESCRIPTION_DEFAULT,
-        help=Messages.TR_TEST_PLAN_DESCRIPTION
+        "--tr-testrun-assignedto-id",
+        action="store",
+        help=Messages.TR_TESTRUN_ASSIGNED_TO,
     )
     parser.addini(
-        'tr-testplan-description',
+        "tr-testrun-assignedto-id", help=Messages.TR_TESTRUN_ASSIGNED_TO, default=None
+    )
+
+    group.addoption(
+        "--tr-testrun-project-id", action="store", help=Messages.TR_TESTRUN_PROJECT_ID
+    )
+    parser.addini(
+        "tr-testrun-project-id", help=Messages.TR_TESTRUN_PROJECT_ID, default=None
+    )
+
+    group.addoption(
+        "--tr-testrun-suite-id", action="store", help=Messages.TR_TESTRUN_SUITE_ID
+    )
+    parser.addini(
+        "tr-testrun-suite-id", help=Messages.TR_TESTRUN_SUITE_ID, default=None
+    )
+
+    group.addoption(
+        "--tr-testrun-suite-include-all",
+        action="store_true",
+        default=False,
+        help=Messages.TR_TESTRUN_SUITE_INCLUDE_ALL,
+    )
+    parser.addini(
+        "tr-testrun-suite-include-all",
+        help=Messages.TR_TESTRUN_SUITE_INCLUDE_ALL,
+        default=False,
+    )
+
+    group.addoption(
+        "--tr-testrun-name", action="store", default=None, help=Messages.TR_TESTRUN_NAME
+    )
+    parser.addini("tr-testrun-name", help=Messages.TR_TESTRUN_NAME, default=None)
+
+    group.addoption(
+        "--tr-testrun-description",
+        action="store",
+        default=None,
+        help=Messages.TR_TESTRUN_DESCRIPTION,
+    )
+    parser.addini(
+        "tr-testrun-description", help=Messages.TR_TESTRUN_DESCRIPTION, default=None
+    )
+
+    group.addoption(
+        "--tr-run-id",
+        action="store",
+        default=0,
+        required=False,
+        help=Messages.TR_RUN_ID,
+    )
+    parser.addini("tr-run-id", help=Messages.TR_RUN_ID, default=0)
+
+    group.addoption(
+        "--tr-plan-id", action="store", required=False, help=Messages.TR_TEST_PLAN_ID
+    )
+    parser.addini("tr-plan-id", help=Messages.TR_TEST_PLAN_ID, default=None)
+
+    group.addoption(
+        "--tr-testplan-name",
+        action="store",
+        default=None,
+        help=Messages.TR_TEST_PLAN_NAME,
+    )
+    parser.addini("tr-testplan-name", help=Messages.TR_TEST_PLAN_NAME, default=None)
+
+    group.addoption(
+        "--tr-testplan-description",
+        action="store",
+        default=Messages.TR_TEST_PLAN_DESCRIPTION_DEFAULT,
         help=Messages.TR_TEST_PLAN_DESCRIPTION,
-        default=Messages.TR_TEST_PLAN_DESCRIPTION_DEFAULT
     )
-
-    group.addoption('--tr-version', action='store', default='', required=False, help=Messages.TR_VERSION)
-    parser.addini('tr-version', help=Messages.TR_VERSION, default='')
-
-    group.addoption('--tr-no-ssl-cert-check', action='store_false', default=None, help=Messages.TR_NO_SSL_CHECK)
-    parser.addini('tr-no-ssl-cert-check', help=Messages.TR_NO_SSL_CHECK, default='')
+    parser.addini(
+        "tr-testplan-description",
+        help=Messages.TR_TEST_PLAN_DESCRIPTION,
+        default=Messages.TR_TEST_PLAN_DESCRIPTION_DEFAULT,
+    )
 
     group.addoption(
-        '--tr-close-on-complete', action='store_true', default=False, required=False, help=Messages.TR_CLOSE_ON_COMPLETE
+        "--tr-version",
+        action="store",
+        default="",
+        required=False,
+        help=Messages.TR_VERSION,
     )
-    parser.addini('tr-close-on-complete', help=Messages.TR_CLOSE_ON_COMPLETE, default=False)
+    parser.addini("tr-version", help=Messages.TR_VERSION, default="")
 
     group.addoption(
-        '--tr-dont-publish-blocked', action='store_false', required=False, help=Messages.TR_DONT_PUBLISH_BLOCKED
+        "--tr-no-ssl-cert-check",
+        action="store_false",
+        default=None,
+        help=Messages.TR_NO_SSL_CHECK,
     )
-    parser.addini('tr-dont-publish-blocked', help=Messages.TR_DONT_PUBLISH_BLOCKED, default=None)
-
-    group.addoption('--tr-skip-missing', action='store_true', required=False, help=Messages.TR_SKIP_MISSING)
-    parser.addini('tr-skip-missing', help=Messages.TR_SKIP_MISSING, default=None)
-
-    group.addoption('--tr-milestone-id', action='store', default=None, required=False, help=Messages.TR_MILESTONE_ID)
-    parser.addini('tr-milestone-id', help=Messages.TR_MILESTONE_ID, default=None)
+    parser.addini("tr-no-ssl-cert-check", help=Messages.TR_NO_SSL_CHECK, default="")
 
     group.addoption(
-        '--tc-custom-comment', action='store', default=None, required=False, help=Messages.TC_CUSTOM_COMMENT
+        "--tr-close-on-complete",
+        action="store_true",
+        default=False,
+        required=False,
+        help=Messages.TR_CLOSE_ON_COMPLETE,
     )
-    parser.addini('tc-custom-comment', help=Messages.TC_CUSTOM_COMMENT, default=None)
+    parser.addini(
+        "tr-close-on-complete", help=Messages.TR_CLOSE_ON_COMPLETE, default=False
+    )
+
+    group.addoption(
+        "--tr-dont-publish-blocked",
+        action="store_false",
+        required=False,
+        help=Messages.TR_DONT_PUBLISH_BLOCKED,
+    )
+    parser.addini(
+        "tr-dont-publish-blocked", help=Messages.TR_DONT_PUBLISH_BLOCKED, default=None
+    )
+
+    group.addoption(
+        "--tr-skip-missing",
+        action="store_true",
+        required=False,
+        help=Messages.TR_SKIP_MISSING,
+    )
+    parser.addini("tr-skip-missing", help=Messages.TR_SKIP_MISSING, default=None)
+
+    group.addoption(
+        "--tr-milestone-id",
+        action="store",
+        default=None,
+        required=False,
+        help=Messages.TR_MILESTONE_ID,
+    )
+    parser.addini("tr-milestone-id", help=Messages.TR_MILESTONE_ID, default=None)
+
+    group.addoption(
+        "--tc-custom-comment",
+        action="store",
+        default=None,
+        required=False,
+        help=Messages.TC_CUSTOM_COMMENT,
+    )
+    parser.addini("tc-custom-comment", help=Messages.TC_CUSTOM_COMMENT, default=None)
+
 
 def pytest_configure(config):
     # Registration marks
-    config.addinivalue_line("markers", "testrail: pytestrail mark (example: @pytestrail")
+    config.addinivalue_line(
+        "markers", "testrail: pytestrail mark (example: @pytestrail"
+    )
     config.addinivalue_line("markers", "testrail_defects: mark for defects")
-    config.addinivalue_line("markers", "testrail_suites: mark for test suite (example: @pytestrail.suite('S11111'))")
+    config.addinivalue_line(
+        "markers",
+        "testrail_suites: mark for test suite (example: @pytestrail.suite('S11111'))",
+    )
 
-    if config.getoption('--testrail'):
-        cfg_file_path = config.getoption('--tr-config')
+    if config.getoption("--testrail"):
+        cfg_file_path = config.getoption("--tr-config")
         config_manager = ConfigManager(cfg_file_path, config)
-        client = APIClient(config_manager.getoption('tr-url', 'url', 'API'),
-                           config_manager.getoption('tr-email', 'email', 'API'),
-                           config_manager.getoption('tr-password', 'password', 'API'),
-                           timeout=config_manager.getoption('tr-timeout', 'timeout', 'API'))
+        client = APIClient(
+            config_manager.getoption("tr-url", "url", "API"),
+            config_manager.getoption("tr-email", "email", "API"),
+            config_manager.getoption("tr-password", "password", "API"),
+            timeout=config_manager.getoption("tr-timeout", "timeout", "API"),
+        )
 
         config.pluginmanager.register(
             PyTestRailPlugin(
                 client=client,
-                assign_user_id=config_manager.getoption('tr-testrun-assignedto-id', 'assignedto_id', 'TESTRUN'),
-                user_email=config_manager.getoption('tr-email', 'email', 'API'),
-                user_password=config_manager.getoption('tr-password', 'password', 'API'),
-                tr_url=config_manager.getoption('tr-url', 'url', 'API'),
-                project_id=config_manager.getoption('tr-testrun-project-id', 'project_id', 'TESTRUN'),
-                suite_id=config_manager.getoption('tr-testrun-suite-id', 'suite_id', 'TESTRUN'),
-                include_all=config_manager.getoption('tr-testrun-suite-include-all', 'include_all', 'TESTRUN',
-                                                     is_bool=True, default=False),
-                cert_check=config_manager.getoption('tr-no-ssl-cert-check', 'no_ssl_cert_check', 'API', is_bool=True,
-                                                    default=True),
-                tr_name=config_manager.getoption('tr-testrun-name', 'name', 'TESTRUN'),
-                tr_description=config_manager.getoption('tr-testrun-description', 'description', 'TESTRUN'),
-                testplan_name=config_manager.getoption('tr-testplan-name', 'name', 'TESTRUN'),
-                testplan_description=config_manager.getoption('tr-testplan-description', 'description', 'TESTRUN'),
-                run_id=config.getoption('--tr-run-id'),
-                plan_id=config_manager.getoption('tr-plan-id', 'plan_id', 'TESTRUN'),
-                version=config.getoption('--tr-version'),
-                close_on_complete=config.getoption('--tr-close-on-complete'),
-                publish_blocked=config.getoption('--tr-dont-publish-blocked'),
-                skip_missing=config.getoption('--tr-skip-missing'),
-                milestone_id=config_manager.getoption('tr-milestone-id', 'milestone_id', 'TESTRUN'),
-                custom_comment=config_manager.getoption('tc-custom-comment', 'custom_comment', 'TESTCASE'),
+                assign_user_id=config_manager.getoption(
+                    "tr-testrun-assignedto-id", "assignedto_id", "TESTRUN"
+                ),
+                user_email=config_manager.getoption("tr-email", "email", "API"),
+                user_password=config_manager.getoption(
+                    "tr-password", "password", "API"
+                ),
+                tr_url=config_manager.getoption("tr-url", "url", "API"),
+                project_id=config_manager.getoption(
+                    "tr-testrun-project-id", "project_id", "TESTRUN"
+                ),
+                suite_id=config_manager.getoption(
+                    "tr-testrun-suite-id", "suite_id", "TESTRUN"
+                ),
+                include_all=config_manager.getoption(
+                    "tr-testrun-suite-include-all",
+                    "include_all",
+                    "TESTRUN",
+                    is_bool=True,
+                    default=False,
+                ),
+                cert_check=config_manager.getoption(
+                    "tr-no-ssl-cert-check",
+                    "no_ssl_cert_check",
+                    "API",
+                    is_bool=True,
+                    default=True,
+                ),
+                tr_name=config_manager.getoption("tr-testrun-name", "name", "TESTRUN"),
+                tr_description=config_manager.getoption(
+                    "tr-testrun-description", "description", "TESTRUN"
+                ),
+                testplan_name=config_manager.getoption(
+                    "tr-testplan-name", "name", "TESTRUN"
+                ),
+                testplan_description=config_manager.getoption(
+                    "tr-testplan-description", "description", "TESTRUN"
+                ),
+                run_id=config.getoption("--tr-run-id"),
+                plan_id=config_manager.getoption("tr-plan-id", "plan_id", "TESTRUN"),
+                version=config.getoption("--tr-version"),
+                close_on_complete=config.getoption("--tr-close-on-complete"),
+                publish_blocked=config.getoption("--tr-dont-publish-blocked"),
+                skip_missing=config.getoption("--tr-skip-missing"),
+                milestone_id=config_manager.getoption(
+                    "tr-milestone-id", "milestone_id", "TESTRUN"
+                ),
+                custom_comment=config_manager.getoption(
+                    "tc-custom-comment", "custom_comment", "TESTCASE"
+                ),
             ),
             # Name of plugin instance (allow to be used by other plugins)
-            name="pytest-testrail-instance"
+            name="pytest-testrail-instance",
         )
 
 
 class ConfigManager(object):
     def __init__(self, cfg_file_path, config):
-        '''
+        """
         Handles retrieving configuration values.
         Config options set in flags are given preferance over options set in the config file.
 
@@ -175,7 +295,7 @@ class ConfigManager(object):
         :type cfg_file_path: str or None
         :param config: Config object containing commandline flag options.
         :type config: _pytest.config.Config
-        '''
+        """
         self.cfg_file = None
         if os.path.isfile(cfg_file_path) or os.path.islink(cfg_file_path):
             self.cfg_file = configparser.ConfigParser()
@@ -187,7 +307,11 @@ class ConfigManager(object):
         # priority: cli > config file > default
 
         # 1. return cli option or pytest.ini option (if set)
-        value = self.config.getoption('--{}'.format(flag)) or self.config.getini(flag) or os.environ.get(flag)
+        value = (
+            self.config.getoption("--{}".format(flag))
+            or self.config.getini(flag)
+            or os.environ.get(flag)
+        )
         if value is not None:
             return value
 
@@ -197,7 +321,11 @@ class ConfigManager(object):
 
         if self.cfg_file.has_option(section, cfg_name):
             # 3. return config file value
-            return self.cfg_file.getboolean(section, cfg_name) if is_bool else self.cfg_file.get(section, cfg_name)
+            return (
+                self.cfg_file.getboolean(section, cfg_name)
+                if is_bool
+                else self.cfg_file.get(section, cfg_name)
+            )
         else:
             # 4. if entry not found in config file
             return default

--- a/pytest_testrail/functions.py
+++ b/pytest_testrail/functions.py
@@ -2,7 +2,7 @@ import re
 import warnings
 
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from pytest_testrail.vars import (
     PYTEST_TO_TESTRAIL_STATUS,
     DT_FORMAT,
@@ -86,13 +86,13 @@ def get_test_outcome(outcome):
 
 def testrun_name():
     """Returns testrun name with timestamp"""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return "Automated Run {}".format(now.strftime(DT_FORMAT))
 
 
 def testplan_name():
     """Returns testrun name with timestamp"""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return "Automated Plan Entry {}".format(now.strftime(DT_FORMAT))
 
 
@@ -111,8 +111,9 @@ def clean_test_ids(test_ids):
     :return list ints: contains list of test_ids as ints.
     """
     return [
-        int(re.search("(?P<test_id>[0-9]+$)", test_id).groupdict().get("test_id"))
+        int(match.group("test_id"))
         for test_id in test_ids
+        if (match := re.search("(?P<test_id>[0-9]+$)", test_id))
     ]
 
 
@@ -124,8 +125,9 @@ def clean_test_defects(defect_ids):
     :return list ints: contains list of defect_ids as ints.
     """
     return [
-        (re.search("(?P<defect_id>.*)", defect_id).groupdict().get("defect_id"))
+        match.group("defect_id")
         for defect_id in defect_ids
+        if (match := re.search("(?P<defect_id>.*)", defect_id))
     ]
 
 
@@ -137,8 +139,9 @@ def clean_suite_ids(suite_ids):
     :return list ints: contains list of suite_ids as ints.
     """
     return [
-        int(re.search("(?P<suite_id>[0-9]+$)", suite_id).groupdict().get("suite_id"))
+        int(match.group("suite_id"))
         for suite_id in suite_ids
+        if (match := re.search("(?P<suite_id>[0-9]+$)", suite_id))
     ]
 
 

--- a/pytest_testrail/functions.py
+++ b/pytest_testrail/functions.py
@@ -3,14 +3,19 @@ import warnings
 
 import pytest
 from datetime import datetime
-from pytest_testrail.vars import PYTEST_TO_TESTRAIL_STATUS, DT_FORMAT, TESTRAIL_PREFIX, TESTRAIL_SUITES_PREFIX
+from pytest_testrail.vars import (
+    PYTEST_TO_TESTRAIL_STATUS,
+    DT_FORMAT,
+    TESTRAIL_PREFIX,
+    TESTRAIL_SUITES_PREFIX,
+)
 
 
 class DeprecatedTestDecorator(DeprecationWarning):
     pass
 
 
-warnings.simplefilter(action='once', category=DeprecatedTestDecorator, lineno=0)
+warnings.simplefilter(action="once", category=DeprecatedTestDecorator, lineno=0)
 
 
 class pytestrail(object):
@@ -44,12 +49,12 @@ class pytestrail(object):
     @staticmethod
     def defect(*defect_ids):
         """
-                Decorator to mark defects with defect ids.
+        Decorator to mark defects with defect ids.
 
-                ie. @pytestrail.defect('PF-513', 'BR-3255')
+        ie. @pytestrail.defect('PF-513', 'BR-3255')
 
-                :return pytest.mark:
-                """
+        :return pytest.mark:
+        """
         return pytest.mark.testrail_defects(defect_ids=defect_ids)
 
 
@@ -61,8 +66,10 @@ def testrail(*ids):
 
     :return pytest.mark:
     """
-    deprecation_msg = ('pytest_testrail: the @testrail decorator is deprecated and will be removed. Please use the '
-                       '@pytestrail.case decorator instead.')
+    deprecation_msg = (
+        "pytest_testrail: the @testrail decorator is deprecated and will be removed. Please use the "
+        "@pytestrail.case decorator instead."
+    )
     warnings.warn(deprecation_msg, DeprecatedTestDecorator)
     return pytestrail.case(*ids)
 
@@ -80,20 +87,20 @@ def get_test_outcome(outcome):
 def testrun_name():
     """Returns testrun name with timestamp"""
     now = datetime.utcnow()
-    return 'Automated Run {}'.format(now.strftime(DT_FORMAT))
+    return "Automated Run {}".format(now.strftime(DT_FORMAT))
 
 
 def testplan_name():
     """Returns testrun name with timestamp"""
     now = datetime.utcnow()
-    return 'Automated Plan Entry {}'.format(now.strftime(DT_FORMAT))
+    return "Automated Plan Entry {}".format(now.strftime(DT_FORMAT))
 
 
 def is_xdist_worker(config):
     """True if the code running the given pytest.config object is running in a xdist master
     node or not running xdist at all.
     """
-    return hasattr(config, 'workerinput')
+    return hasattr(config, "workerinput")
 
 
 def clean_test_ids(test_ids):
@@ -103,27 +110,36 @@ def clean_test_ids(test_ids):
     :param list test_ids: list of test_ids.
     :return list ints: contains list of test_ids as ints.
     """
-    return [int(re.search('(?P<test_id>[0-9]+$)', test_id).groupdict().get('test_id')) for test_id in test_ids]
+    return [
+        int(re.search("(?P<test_id>[0-9]+$)", test_id).groupdict().get("test_id"))
+        for test_id in test_ids
+    ]
 
 
 def clean_test_defects(defect_ids):
     """
-        Clean pytest marker containing testrail defects ids.
+    Clean pytest marker containing testrail defects ids.
 
-        :param list defect_ids: list of defect_ids.
-        :return list ints: contains list of defect_ids as ints.
-        """
-    return [(re.search('(?P<defect_id>.*)', defect_id).groupdict().get('defect_id')) for defect_id in defect_ids]
+    :param list defect_ids: list of defect_ids.
+    :return list ints: contains list of defect_ids as ints.
+    """
+    return [
+        (re.search("(?P<defect_id>.*)", defect_id).groupdict().get("defect_id"))
+        for defect_id in defect_ids
+    ]
 
 
 def clean_suite_ids(suite_ids):
     """
-        Clean pytest marker containing testrail suite ids.
+    Clean pytest marker containing testrail suite ids.
 
-        :param list suite_ids: list of suite_ids.
-        :return list ints: contains list of suite_ids as ints.
-        """
-    return [int(re.search('(?P<suite_id>[0-9]+$)', suite_id).groupdict().get('suite_id')) for suite_id in suite_ids]
+    :param list suite_ids: list of suite_ids.
+    :return list ints: contains list of suite_ids as ints.
+    """
+    return [
+        int(re.search("(?P<suite_id>[0-9]+$)", suite_id).groupdict().get("suite_id"))
+        for suite_id in suite_ids
+    ]
 
 
 def get_case_list(tests: list):
@@ -133,7 +149,7 @@ def get_case_list(tests: list):
     """
     testcaseids = []
     for test in tests or []:
-        testcaseids.append(test['case_id'])
+        testcaseids.append(test["case_id"])
     return testcaseids
 
 
@@ -146,8 +162,8 @@ def get_testrail_keys(items):
                 (
                     item,
                     clean_test_ids(
-                        item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
-                    )
+                        item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get("ids")
+                    ),
                 )
             )
     return testcaseids
@@ -160,7 +176,11 @@ def get_testrail_suite_ids(items) -> list:
             suite_ids.append(
                 (
                     item,
-                    clean_suite_ids(item.get_closest_marker(TESTRAIL_SUITES_PREFIX).kwargs.get('ids'))
+                    clean_suite_ids(
+                        item.get_closest_marker(TESTRAIL_SUITES_PREFIX).kwargs.get(
+                            "ids"
+                        )
+                    ),
                 )
             )
 
@@ -171,9 +191,9 @@ def filter_publish_results(results, ignore_cases):
     clear_results = []
     test_case_ids_list = []
     for result in results:
-        if int(result['case_id']) not in ignore_cases:
+        if int(result["case_id"]) not in ignore_cases:
             clear_results.append(result)
-            test_case_ids_list.append(str(result['case_id']))
+            test_case_ids_list.append(str(result["case_id"]))
     return clear_results, test_case_ids_list
 
 

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_testrail.TestrailModel import TestRailModel
 from pytest_testrail.testrail_actions import TestrailActions
 from pytest_testrail.vars import TESTRAIL_DEFECTS_PREFIX, TESTRAIL_PREFIX
-from pytest_testrail.functions import get_testrail_keys, testrun_name, clean_test_ids, \
+from pytest_testrail.functions import testrail, pytestrail, get_testrail_keys, testrun_name, clean_test_ids, \
     get_test_outcome, clean_test_defects, is_xdist_worker, get_testrail_suite_ids, get_suite_by_case
 
 
@@ -44,6 +44,39 @@ class PyTestRailPlugin(TestrailActions):
                                            )
         super().__init__(testrail_data=self.testrail_data)
         self.is_use_xdist = False
+
+    # Property proxies for backward compatibility and test access
+    @property
+    def results(self):
+        return self.testrail_data.results
+
+    @results.setter
+    def results(self, value):
+        self.testrail_data.results = value
+
+    @property
+    def testrun_id(self):
+        return self.testrail_data.testrun_id
+
+    @testrun_id.setter
+    def testrun_id(self, value):
+        self.testrail_data.testrun_id = value
+
+    @property
+    def testplan_id(self):
+        return self.testrail_data.testplan_id
+
+    @testplan_id.setter
+    def testplan_id(self, value):
+        self.testrail_data.testplan_id = value
+
+    @property
+    def close_on_complete(self):
+        return self.testrail_data.close_on_complete
+
+    @close_on_complete.setter
+    def close_on_complete(self, value):
+        self.testrail_data.close_on_complete = value
 
     @pytest.fixture(scope='function')
     def testrail_comment(self, request):
@@ -182,7 +215,7 @@ class PyTestRailPlugin(TestrailActions):
 
         if self.testrail_data.skip_missing:
             for item, case_id in items_with_tr_keys:
-                if set(case_id).intersection(set(self.testrail_data.diff_case_ids)):
+                if set(case_id).issubset(set(self.testrail_data.diff_case_ids)):
                     mark = pytest.mark.skip(f'[{TESTRAIL_PREFIX}] Test {case_id} is not present in testrun.')
                     item.add_marker(mark)
 

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -67,6 +67,7 @@ class PyTestRailPlugin(TestrailActions):
             user_password=user_password,
             tr_url=tr_url,
             actual_suites_with_case_ids={},
+            available_suite_ids={},
             plan_entry_storage={},
             diff_case_ids=[],
             test_comments=[],
@@ -121,7 +122,7 @@ class PyTestRailPlugin(TestrailActions):
             self.testrail_data.project_id,
             self.testrail_data.testplan_name,
             self.testrail_data.milestone_id,
-            self.testrail_data.testplan_description,
+            self.testrail_data.testplan_description or "",
         )
 
     def _create_test_plan_entry(self, suite_id=None, test_suite_name=""):
@@ -134,7 +135,7 @@ class PyTestRailPlugin(TestrailActions):
             tr_keys=self.testrail_data.actual_suites_with_case_ids[
                 suite_id if suite_id else self.testrail_data.suite_id
             ],
-            description=self.testrail_data.testrun_description,
+            description=self.testrail_data.testrun_description or "",
         )
 
     def _create_test_run(self, suite_id=None, test_suite_name=""):
@@ -148,7 +149,7 @@ class PyTestRailPlugin(TestrailActions):
                 suite_id if suite_id else self.testrail_data.suite_id
             ],
             milestone_id=self.testrail_data.milestone_id,
-            description=self.testrail_data.testrun_description,
+            description=self.testrail_data.testrun_description or "",
         )
 
     def create_report_entries(self):
@@ -190,14 +191,14 @@ class PyTestRailPlugin(TestrailActions):
                     self._create_test_plan_entry(
                         suite_id=suite_id,
                         test_suite_name=self.testrail_data.available_suite_ids.get(
-                            suite_id
+                            suite_id, ""
                         ),
                     )
                 else:
                     self._create_test_run(
                         suite_id=suite_id,
                         test_suite_name=self.testrail_data.available_suite_ids.get(
-                            suite_id
+                            suite_id, ""
                         ),
                     )
 
@@ -224,12 +225,9 @@ class PyTestRailPlugin(TestrailActions):
 
         # ---------------------------------------------
         testrail_list_of_suites_and_cases = {}
-        self.testrail_data.available_suite_ids = self.get_suites(
-            project_id=self.testrail_data.project_id
-        )
+        raw_suites = self.get_suites(project_id=self.testrail_data.project_id)
         self.testrail_data.available_suite_ids = {
-            suite["id"]: suite["name"]
-            for suite in self.testrail_data.available_suite_ids
+            suite["id"]: suite["name"] for suite in raw_suites
         }
         # got a list of test suites [11234,34234,123213]
         if self.testrail_data.suite_id:
@@ -291,7 +289,10 @@ class PyTestRailPlugin(TestrailActions):
                 f"[{TESTRAIL_PREFIX}] Diff: {self.testrail_data.diff_case_ids}"
             )
 
-        self.create_report_entries()
+        # Only create test runs/plan entries on non-xdist or controller.
+        # Workers just need collection data for get_suite_by_case during execution.
+        if not is_xdist_worker(config=config):
+            self.create_report_entries()
 
         if self.testrail_data.skip_missing:
             for item, case_id in items_with_tr_keys:
@@ -307,7 +308,7 @@ class PyTestRailPlugin(TestrailActions):
         outcome = yield
 
         rep = outcome.get_result()
-        defect_ids = None
+        defect_ids: list | None = None
         test_parametrize = None
         report_messages = []
         test_comments: list = []
@@ -356,7 +357,6 @@ class PyTestRailPlugin(TestrailActions):
                             test_comments=test_comments,
                         )
                     )
-            return None
 
     @pytest.hookimpl(tryfirst=True)
     def pytest_sessionstart(self, session):
@@ -379,26 +379,38 @@ class PyTestRailPlugin(TestrailActions):
         """Publish results in TestRail"""
         yield
         if is_xdist_worker(config=session.config):
-            # Workers send their results to the controller via workeroutput.
+            # Workers send their results and collection data to the controller.
             # Publishing is done only by the controller.
             session.config.workeroutput["testrail_results"] = self.testrail_data.results
+            session.config.workeroutput["actual_suites_with_case_ids"] = json.dumps(
+                {
+                    str(k): v
+                    for k, v in self.testrail_data.actual_suites_with_case_ids.items()
+                }
+            )
+            session.config.workeroutput["available_suite_ids"] = json.dumps(
+                {str(k): v for k, v in self.testrail_data.available_suite_ids.items()}
+            )
             return
         # Controller or non-xdist run: publish all collected results once.
-        self.publish_results(
-            testrail_data=self.testrail_data, results=self.testrail_data.results
-        )
+        self.publish_results(results=self.testrail_data.results)
 
     def pytest_configure(self, config):
-        if config.pluginmanager.hasplugin("xdist"):
-            config.pluginmanager.register(NodeAction(self.testrail_data))
+        if config.pluginmanager.hasplugin("xdist") and not is_xdist_worker(
+            config=config
+        ):
+            config.pluginmanager.register(
+                NodeAction(self.testrail_data), name="pytest-testrail-node-action"
+            )
 
 
 class NodeAction(TestrailActions):
     def __init__(self, testrail_data):
         self.testrail_data = testrail_data
+        self._entries_created = False
         super().__init__(testrail_data=self.testrail_data)
 
-    def pytest_configure_node(self, node):  # type: ignore
+    def pytest_configure_node(self, node):
         node.workerinput["test_run_id"] = self.testrail_data.testrun_id
         node.workerinput["actual_suites_with_case_ids"] = json.dumps(
             {
@@ -407,7 +419,87 @@ class NodeAction(TestrailActions):
             }
         )
 
-    def pytest_testnodedown(self, node, error):  # type: ignore
-        """Collect results from each worker after it finishes."""
+    def _create_report_entries(self):
+        """Create test runs/plan entries on the controller side."""
+        if self.testrail_data.testrun_id:
+            run_info = self.get_run(run_id=self.testrail_data.testrun_id)
+            if run_info["plan_id"]:
+                entry_id = self.get_testplan_entry_id(
+                    plan_id=run_info["plan_id"], run_id=self.testrail_data.testrun_id
+                )
+                self.update_testplan_entry(
+                    plan_id=run_info["plan_id"],
+                    entry_id=entry_id,
+                    run_id=self.testrail_data.testrun_id,
+                    tr_keys=self.testrail_data.actual_suites_with_case_ids[
+                        run_info["suite_id"]
+                    ],
+                    suite_id=run_info["suite_id"],
+                    save_previous=True,
+                )
+            else:
+                self.update_testrun(
+                    testrun_id=self.testrail_data.testrun_id,
+                    tr_keys=self.testrail_data.actual_suites_with_case_ids[
+                        run_info["suite_id"]
+                    ],
+                    suite_id=run_info["suite_id"],
+                    save_previous=True,
+                )
+        else:
+            for suite_id in self.testrail_data.actual_suites_with_case_ids.keys():
+                if not self.testrail_data.actual_suites_with_case_ids[suite_id]:
+                    print(
+                        f"[{TESTRAIL_PREFIX}] No testcases for suite {suite_id}! Testrun not created"
+                    )
+                    continue
+                if self.testrail_data.testplan_id:
+                    self.create_plan_entry(
+                        suite_id=suite_id,
+                        testrun_name=f"[ {self.testrail_data.available_suite_ids.get(suite_id, '')} ] "
+                        f"{self.testrail_data.testrun_name or testrun_name()}",
+                        assign_user_id=self.testrail_data.assign_user_id,
+                        plan_id=self.testrail_data.testplan_id,
+                        include_all=self.testrail_data.include_all,
+                        tr_keys=self.testrail_data.actual_suites_with_case_ids[
+                            suite_id
+                        ],
+                        description=self.testrail_data.testrun_description or "",
+                    )
+                else:
+                    self.create_test_run(
+                        assign_user_id=self.testrail_data.assign_user_id,
+                        project_id=self.testrail_data.project_id,
+                        suite_id=suite_id,
+                        include_all=self.testrail_data.include_all,
+                        testrun_name=f"[ {self.testrail_data.available_suite_ids.get(suite_id, '')} ] "
+                        f"{self.testrail_data.testrun_name or testrun_name()}",
+                        tr_keys=self.testrail_data.actual_suites_with_case_ids[
+                            suite_id
+                        ],
+                        milestone_id=self.testrail_data.milestone_id,
+                        description=self.testrail_data.testrun_description or "",
+                    )
+
+    def pytest_testnodedown(self, node, error):
+        """Collect results and collection data from each worker after it finishes."""
         worker_results = node.workeroutput.get("testrail_results", [])
         self.testrail_data.results.extend(worker_results)
+
+        # Merge worker's collection data into controller
+        raw_suites = node.workeroutput.get("actual_suites_with_case_ids", "{}")
+        for k, v in json.loads(raw_suites).items():
+            suite_id = int(k)
+            if suite_id not in self.testrail_data.actual_suites_with_case_ids:
+                self.testrail_data.actual_suites_with_case_ids[suite_id] = v
+
+        raw_available = node.workeroutput.get("available_suite_ids", "{}")
+        for k, v in json.loads(raw_available).items():
+            suite_id = int(k)
+            if suite_id not in self.testrail_data.available_suite_ids:
+                self.testrail_data.available_suite_ids[suite_id] = v
+
+        # Create test run/plan entries once after receiving data from first worker
+        if not self._entries_created and self.testrail_data.actual_suites_with_case_ids:
+            self._create_report_entries()
+            self._entries_created = True

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -1,10 +1,11 @@
 # -*- coding: UTF-8 -*-
+import json
 import pytest
 
 from pytest_testrail.TestrailModel import TestRailModel
 from pytest_testrail.testrail_actions import TestrailActions
 from pytest_testrail.vars import TESTRAIL_DEFECTS_PREFIX, TESTRAIL_PREFIX
-from pytest_testrail.functions import testrail, pytestrail, get_testrail_keys, testrun_name, clean_test_ids, \
+from pytest_testrail.functions import get_testrail_keys, testrun_name, clean_test_ids, \
     get_test_outcome, clean_test_defects, is_xdist_worker, get_testrail_suite_ids, get_suite_by_case
 
 
@@ -43,7 +44,6 @@ class PyTestRailPlugin(TestrailActions):
                                            test_comments=[]
                                            )
         super().__init__(testrail_data=self.testrail_data)
-        self.is_use_xdist = False
 
     # Property proxies for backward compatibility and test access
     @property
@@ -231,7 +231,7 @@ class PyTestRailPlugin(TestrailActions):
         test_comments: list = []
 
         if 'callspec' in dir(item):
-            test_parametrize = item.callspec.params
+            test_parametrize = str(item.callspec.params)
 
         if hasattr(rep, 'sections'):
             for section in rep.sections:
@@ -269,6 +269,10 @@ class PyTestRailPlugin(TestrailActions):
     def pytest_sessionstart(self, session):
         if is_xdist_worker(config=session.config):
             self.testrail_data.testrun_id = session.config.workerinput["test_run_id"]
+            raw = session.config.workerinput.get("actual_suites_with_case_ids", "{}")
+            self.testrail_data.actual_suites_with_case_ids = {
+                int(k): v for k, v in json.loads(raw).items()
+            }
         else:
             if not self.testrail_data.testrun_id and not self.testrail_data.testplan_id \
                     and self.testrail_data.testplan_name:
@@ -278,14 +282,13 @@ class PyTestRailPlugin(TestrailActions):
     def pytest_sessionfinish(self, session, exitstatus):
         """ Publish results in TestRail """
         yield
-        if session.config.pluginmanager.get_plugin("xdist"):
-            if is_xdist_worker(config=session.config):
-                self.is_use_xdist = True
-                self.publish_results(testrail_data=self.testrail_data, results=self.testrail_data.results)
-            if not self.is_use_xdist and not session.config.getoption("numprocesses"):
-                self.publish_results(testrail_data=self.testrail_data, results=self.testrail_data.results)
-        else:
-            self.publish_results(testrail_data=self.testrail_data, results=self.testrail_data.results)
+        if is_xdist_worker(config=session.config):
+            # Workers send their results to the controller via workeroutput.
+            # Publishing is done only by the controller.
+            session.config.workeroutput['testrail_results'] = self.testrail_data.results
+            return
+        # Controller or non-xdist run: publish all collected results once.
+        self.publish_results(testrail_data=self.testrail_data, results=self.testrail_data.results)
 
     def pytest_configure(self, config):
         if config.pluginmanager.hasplugin("xdist"):
@@ -300,3 +303,11 @@ class NodeAction(TestrailActions):
 
     def pytest_configure_node(self, node):  # type: ignore
         node.workerinput["test_run_id"] = self.testrail_data.testrun_id
+        node.workerinput["actual_suites_with_case_ids"] = json.dumps(
+            {str(k): v for k, v in self.testrail_data.actual_suites_with_case_ids.items()}
+        )
+
+    def pytest_testnodedown(self, node, error):  # type: ignore
+        """Collect results from each worker after it finishes."""
+        worker_results = node.workeroutput.get('testrail_results', [])
+        self.testrail_data.results.extend(worker_results)

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -5,44 +5,72 @@ import pytest
 from pytest_testrail.TestrailModel import TestRailModel
 from pytest_testrail.testrail_actions import TestrailActions
 from pytest_testrail.vars import TESTRAIL_DEFECTS_PREFIX, TESTRAIL_PREFIX
-from pytest_testrail.functions import get_testrail_keys, testrun_name, clean_test_ids, \
-    get_test_outcome, clean_test_defects, is_xdist_worker, get_testrail_suite_ids, get_suite_by_case
+from pytest_testrail.functions import (
+    get_testrail_keys,
+    testrun_name,
+    clean_test_ids,
+    get_test_outcome,
+    clean_test_defects,
+    is_xdist_worker,
+    get_testrail_suite_ids,
+    get_suite_by_case,
+)
 
 
 class PyTestRailPlugin(TestrailActions):
-
-    def __init__(self, client, assign_user_id, project_id, suite_id, include_all, cert_check, tr_name,
-                 tr_description='', testplan_name=None, testplan_description=None, run_id=0, plan_id=0, version='',
-                 close_on_complete=False, publish_blocked=True, skip_missing=False, milestone_id=None,
-                 custom_comment=None, user_email=None, user_password=None, tr_url=None):
-        self.testrail_data = TestRailModel(assign_user_id=assign_user_id,
-                                           cert_check=cert_check,
-                                           client=client,
-                                           project_id=project_id,
-                                           results=[],
-                                           suite_id=suite_id,
-                                           include_all=include_all,
-                                           testrun_name=tr_name,
-                                           testrun_description=tr_description,
-                                           testrun_id=run_id,
-                                           testplan_id=plan_id,
-                                           testplan_name=testplan_name,
-                                           testplan_description=testplan_description,
-                                           version=version,
-                                           close_on_complete=close_on_complete,
-                                           publish_blocked=publish_blocked,
-                                           skip_missing=skip_missing,
-                                           milestone_id=milestone_id,
-                                           custom_comment=custom_comment,
-                                           tr_keys=[],
-                                           user_email=user_email,
-                                           user_password=user_password,
-                                           tr_url=tr_url,
-                                           actual_suites_with_case_ids={},
-                                           plan_entry_storage={},
-                                           diff_case_ids=[],
-                                           test_comments=[]
-                                           )
+    def __init__(
+        self,
+        client,
+        assign_user_id,
+        project_id,
+        suite_id,
+        include_all,
+        cert_check,
+        tr_name,
+        tr_description="",
+        testplan_name=None,
+        testplan_description=None,
+        run_id=0,
+        plan_id=0,
+        version="",
+        close_on_complete=False,
+        publish_blocked=True,
+        skip_missing=False,
+        milestone_id=None,
+        custom_comment=None,
+        user_email=None,
+        user_password=None,
+        tr_url=None,
+    ):
+        self.testrail_data = TestRailModel(
+            assign_user_id=assign_user_id,
+            cert_check=cert_check,
+            client=client,
+            project_id=project_id,
+            results=[],
+            suite_id=suite_id,
+            include_all=include_all,
+            testrun_name=tr_name,
+            testrun_description=tr_description,
+            testrun_id=run_id,
+            testplan_id=plan_id,
+            testplan_name=testplan_name,
+            testplan_description=testplan_description,
+            version=version,
+            close_on_complete=close_on_complete,
+            publish_blocked=publish_blocked,
+            skip_missing=skip_missing,
+            milestone_id=milestone_id,
+            custom_comment=custom_comment,
+            tr_keys=[],
+            user_email=user_email,
+            user_password=user_password,
+            tr_url=tr_url,
+            actual_suites_with_case_ids={},
+            plan_entry_storage={},
+            diff_case_ids=[],
+            test_comments=[],
+        )
         super().__init__(testrail_data=self.testrail_data)
 
     # Property proxies for backward compatibility and test access
@@ -78,9 +106,9 @@ class PyTestRailPlugin(TestrailActions):
     def close_on_complete(self, value):
         self.testrail_data.close_on_complete = value
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture(scope="function")
     def testrail_comment(self, request):
-        """ this is fixture for adding pytest report section """
+        """this is fixture for adding pytest report section"""
 
         def _add_section(*args):
             for arg in args:
@@ -88,76 +116,105 @@ class PyTestRailPlugin(TestrailActions):
 
         yield _add_section
 
-
     def _create_test_plan(self):
-        self.create_plan(self.testrail_data.project_id,
-                         self.testrail_data.testplan_name,
-                         self.testrail_data.milestone_id,
-                         self.testrail_data.testplan_description)
+        self.create_plan(
+            self.testrail_data.project_id,
+            self.testrail_data.testplan_name,
+            self.testrail_data.milestone_id,
+            self.testrail_data.testplan_description,
+        )
 
-    def _create_test_plan_entry(self, suite_id=None, test_suite_name=''):
-        self.create_plan_entry(suite_id=suite_id if suite_id else self.testrail_data.suite_id,
-                               testrun_name=f'[ {test_suite_name} ] {self.testrail_data.testrun_name or testrun_name()}',
-                               assign_user_id=self.testrail_data.assign_user_id,
-                               plan_id=self.testrail_data.testplan_id,
-                               include_all=self.testrail_data.include_all,
-                               tr_keys=self.testrail_data.actual_suites_with_case_ids[
-                                   suite_id if suite_id else self.testrail_data.suite_id],
-                               description=self.testrail_data.testrun_description
-                               )
+    def _create_test_plan_entry(self, suite_id=None, test_suite_name=""):
+        self.create_plan_entry(
+            suite_id=suite_id if suite_id else self.testrail_data.suite_id,
+            testrun_name=f"[ {test_suite_name} ] {self.testrail_data.testrun_name or testrun_name()}",
+            assign_user_id=self.testrail_data.assign_user_id,
+            plan_id=self.testrail_data.testplan_id,
+            include_all=self.testrail_data.include_all,
+            tr_keys=self.testrail_data.actual_suites_with_case_ids[
+                suite_id if suite_id else self.testrail_data.suite_id
+            ],
+            description=self.testrail_data.testrun_description,
+        )
 
-    def _create_test_run(self, suite_id=None, test_suite_name=''):
-        self.create_test_run(assign_user_id=self.testrail_data.assign_user_id,
-                             project_id=self.testrail_data.project_id,
-                             suite_id=suite_id if suite_id else self.testrail_data.suite_id,
-                             include_all=self.testrail_data.include_all,
-                             testrun_name=f'[ {test_suite_name} ] {self.testrail_data.testrun_name or testrun_name()}',
-                             tr_keys=self.testrail_data.actual_suites_with_case_ids[
-                                 suite_id if suite_id else self.testrail_data.suite_id],
-                             milestone_id=self.testrail_data.milestone_id,
-                             description=self.testrail_data.testrun_description
-                             )
+    def _create_test_run(self, suite_id=None, test_suite_name=""):
+        self.create_test_run(
+            assign_user_id=self.testrail_data.assign_user_id,
+            project_id=self.testrail_data.project_id,
+            suite_id=suite_id if suite_id else self.testrail_data.suite_id,
+            include_all=self.testrail_data.include_all,
+            testrun_name=f"[ {test_suite_name} ] {self.testrail_data.testrun_name or testrun_name()}",
+            tr_keys=self.testrail_data.actual_suites_with_case_ids[
+                suite_id if suite_id else self.testrail_data.suite_id
+            ],
+            milestone_id=self.testrail_data.milestone_id,
+            description=self.testrail_data.testrun_description,
+        )
 
     def create_report_entries(self):
         if self.testrail_data.testrun_id:
             # update specified test run
             run_info = self.get_run(run_id=self.testrail_data.testrun_id)
-            if run_info['plan_id']:
-                entry_id = self.get_testplan_entry_id(plan_id=run_info['plan_id'],
-                                                      run_id=self.testrail_data.testrun_id
-                                                      )
-                self.update_testplan_entry(plan_id=run_info['plan_id'], entry_id=entry_id,
-                                           run_id=self.testrail_data.testrun_id,
-                                           tr_keys=self.testrail_data.actual_suites_with_case_ids[run_info['suite_id']],
-                                           suite_id=run_info['suite_id'],
-                                           save_previous=True)
+            if run_info["plan_id"]:
+                entry_id = self.get_testplan_entry_id(
+                    plan_id=run_info["plan_id"], run_id=self.testrail_data.testrun_id
+                )
+                self.update_testplan_entry(
+                    plan_id=run_info["plan_id"],
+                    entry_id=entry_id,
+                    run_id=self.testrail_data.testrun_id,
+                    tr_keys=self.testrail_data.actual_suites_with_case_ids[
+                        run_info["suite_id"]
+                    ],
+                    suite_id=run_info["suite_id"],
+                    save_previous=True,
+                )
             else:
-                self.update_testrun(testrun_id=self.testrail_data.testrun_id,
-                                    tr_keys=self.testrail_data.actual_suites_with_case_ids[run_info['suite_id']],
-                                    suite_id=run_info['suite_id'],
-                                    save_previous=True)
+                self.update_testrun(
+                    testrun_id=self.testrail_data.testrun_id,
+                    tr_keys=self.testrail_data.actual_suites_with_case_ids[
+                        run_info["suite_id"]
+                    ],
+                    suite_id=run_info["suite_id"],
+                    save_previous=True,
+                )
         else:
             # create testrun for each suite
             for suite_id in self.testrail_data.actual_suites_with_case_ids.keys():
                 if not self.testrail_data.actual_suites_with_case_ids[suite_id]:
-                    print(f"[{TESTRAIL_PREFIX}] No testcases for suite {suite_id}! Testrun not created")
+                    print(
+                        f"[{TESTRAIL_PREFIX}] No testcases for suite {suite_id}! Testrun not created"
+                    )
                     continue
                 if self.testrail_data.testplan_id:
-                    self._create_test_plan_entry(suite_id=suite_id,
-                                                 test_suite_name=self.testrail_data.available_suite_ids.get(suite_id))
+                    self._create_test_plan_entry(
+                        suite_id=suite_id,
+                        test_suite_name=self.testrail_data.available_suite_ids.get(
+                            suite_id
+                        ),
+                    )
                 else:
-                    self._create_test_run(suite_id=suite_id, test_suite_name=self.testrail_data.available_suite_ids.get(suite_id))
+                    self._create_test_run(
+                        suite_id=suite_id,
+                        test_suite_name=self.testrail_data.available_suite_ids.get(
+                            suite_id
+                        ),
+                    )
 
     # pytest hooks
-    def pytest_report_header(self, config, startdir):
-        """ Add extra-info in header """
-        message = f'[{TESTRAIL_PREFIX}]: '
+    def pytest_report_header(self, config):
+        """Add extra-info in header"""
+        message = f"[{TESTRAIL_PREFIX}]: "
         if self.testrail_data.testplan_id:
-            message += 'existing testplan #{} selected'.format(self.testrail_data.testplan_id)
+            message += "existing testplan #{} selected".format(
+                self.testrail_data.testplan_id
+            )
         elif self.testrail_data.testrun_id:
-            message += 'existing testrun #{} selected'.format(self.testrail_data.testrun_id)
+            message += "existing testrun #{} selected".format(
+                self.testrail_data.testrun_id
+            )
         else:
-            message += 'a new testrun will be created'
+            message += "a new testrun will be created"
         return message
 
     @pytest.hookimpl(trylast=True)
@@ -167,8 +224,13 @@ class PyTestRailPlugin(TestrailActions):
 
         # ---------------------------------------------
         testrail_list_of_suites_and_cases = {}
-        self.testrail_data.available_suite_ids = self.get_suites(project_id=self.testrail_data.project_id)
-        self.testrail_data.available_suite_ids = {suite['id']: suite['name'] for suite in self.testrail_data.available_suite_ids}
+        self.testrail_data.available_suite_ids = self.get_suites(
+            project_id=self.testrail_data.project_id
+        )
+        self.testrail_data.available_suite_ids = {
+            suite["id"]: suite["name"]
+            for suite in self.testrail_data.available_suite_ids
+        }
         # got a list of test suites [11234,34234,123213]
         if self.testrail_data.suite_id:
             suite_ids = {int(self.testrail_data.suite_id)}
@@ -179,49 +241,69 @@ class PyTestRailPlugin(TestrailActions):
 
             for suite_id in suite_ids:
                 if suite_id not in self.testrail_data.available_suite_ids.keys():
-                    print(f"[{TESTRAIL_PREFIX}] Test suite ({suite_id}) not available "
-                          f"for project_id: {self.testrail_data.project_id}")
+                    print(
+                        f"[{TESTRAIL_PREFIX}] Test suite ({suite_id}) not available "
+                        f"for project_id: {self.testrail_data.project_id}"
+                    )
 
         # got a list of test suites with corresponding test cases from the Testrail
         for suite_id in suite_ids:
-            testrail_list_of_suites_and_cases[suite_id] = \
-                [test.get('id') for test in self.get_cases(self.testrail_data.project_id, suite_id)]
+            testrail_list_of_suites_and_cases[suite_id] = [
+                test.get("id")
+                for test in self.get_cases(self.testrail_data.project_id, suite_id)
+            ]
 
         # ---------------------------------------------
         # got a list of all the test ids in the run
-        pytest_case_ids = [case_id for item in items_with_tr_keys for case_id in item[1]]
+        pytest_case_ids = [
+            case_id for item in items_with_tr_keys for case_id in item[1]
+        ]
 
         # got a list of all the test cases from all the test suites
-        suite_case_ids = [case for value in testrail_list_of_suites_and_cases for case in
-                          testrail_list_of_suites_and_cases[value]]
+        suite_case_ids = [
+            case
+            for value in testrail_list_of_suites_and_cases
+            for case in testrail_list_of_suites_and_cases[value]
+        ]
 
         # got a list of test cases to run.
-        self.testrail_data.tr_keys = [case for case in pytest_case_ids if case in suite_case_ids]
+        self.testrail_data.tr_keys = [
+            case for case in pytest_case_ids if case in suite_case_ids
+        ]
 
         # received a list of test suites with participating test cases in the run
         for suite_id in suite_ids:
             self.testrail_data.actual_suites_with_case_ids[suite_id] = list(
-                set(pytest_case_ids).intersection(testrail_list_of_suites_and_cases[suite_id]))
+                set(pytest_case_ids).intersection(
+                    testrail_list_of_suites_and_cases[suite_id]
+                )
+            )
         print(f"[{TESTRAIL_PREFIX}] PyTest cases: {pytest_case_ids}")
         # received a list of test cases that are not in the run
-        self.testrail_data.diff_case_ids = list(set(pytest_case_ids).difference(suite_case_ids))
+        self.testrail_data.diff_case_ids = list(
+            set(pytest_case_ids).difference(suite_case_ids)
+        )
 
         # Showed a list of test cases that are not in the test suites
         if self.testrail_data.diff_case_ids:
-            print(f"[{TESTRAIL_PREFIX}] In pytest run have testcases that not exist in suites\n"
-                  f"[{TESTRAIL_PREFIX}] Diff: {self.testrail_data.diff_case_ids}")
+            print(
+                f"[{TESTRAIL_PREFIX}] In pytest run have testcases that not exist in suites\n"
+                f"[{TESTRAIL_PREFIX}] Diff: {self.testrail_data.diff_case_ids}"
+            )
 
         self.create_report_entries()
 
         if self.testrail_data.skip_missing:
             for item, case_id in items_with_tr_keys:
                 if set(case_id).issubset(set(self.testrail_data.diff_case_ids)):
-                    mark = pytest.mark.skip(f'[{TESTRAIL_PREFIX}] Test {case_id} is not present in testrun.')
+                    mark = pytest.mark.skip(
+                        f"[{TESTRAIL_PREFIX}] Test {case_id} is not present in testrun."
+                    )
                     item.add_marker(mark)
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
     def pytest_runtest_makereport(self, item, call):
-        """ Collect result and associated testcases (TestRail) of an execution """
+        """Collect result and associated testcases (TestRail) of an execution"""
         outcome = yield
 
         rep = outcome.get_result()
@@ -230,39 +312,50 @@ class PyTestRailPlugin(TestrailActions):
         report_messages = []
         test_comments: list = []
 
-        if 'callspec' in dir(item):
+        if "callspec" in dir(item):
             test_parametrize = str(item.callspec.params)
 
-        if hasattr(rep, 'sections'):
+        if hasattr(rep, "sections"):
             for section in rep.sections:
                 if "testrail_comment" in section[0]:
                     test_comments.append(section[1])
         if rep.when == "call" and rep.failed:
             report_messages.append(rep.longreprtext)
-        if rep.skipped and hasattr(rep, 'wasxfail'):
-            report_messages.append(f'\nXFail: {rep.wasxfail}')
+        if rep.skipped and hasattr(rep, "wasxfail"):
+            report_messages.append(f"\nXFail: {rep.wasxfail}")
 
-        comment = '\n'.join(report_messages)
+        comment = "\n".join(report_messages)
 
         if item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX):
-            defect_ids = item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX).kwargs.get('defect_ids')
+            defect_ids = item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX).kwargs.get(
+                "defect_ids"
+            )
         if item.get_closest_marker(TESTRAIL_PREFIX):
-            testcase_ids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
-            if rep.when == 'call' and testcase_ids:
+            testcase_ids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get("ids")
+            if rep.when == "call" and testcase_ids:
                 for testcase_id in clean_test_ids(testcase_ids):
-                    suite_id = get_suite_by_case(case=testcase_id,
-                                                 suites=self.testrail_data.actual_suites_with_case_ids)
+                    suite_id = get_suite_by_case(
+                        case=testcase_id,
+                        suites=self.testrail_data.actual_suites_with_case_ids,
+                    )
 
-                    self.testrail_data.results.append(self.add_result(
-                        testcase_id,
-                        get_test_outcome(outcome.get_result().outcome),
-                        comment=comment,
-                        duration=rep.duration,
-                        defects=str(clean_test_defects(defect_ids)).replace('[', '').replace(']', '').replace("'",
-                                                                                                              '') if defect_ids else None,
-                        test_parametrize=test_parametrize,
-                        suite_id=suite_id,
-                        test_comments=test_comments))
+                    self.testrail_data.results.append(
+                        self.add_result(
+                            testcase_id,
+                            get_test_outcome(outcome.get_result().outcome),
+                            comment=comment,
+                            duration=rep.duration,
+                            defects=str(clean_test_defects(defect_ids))
+                            .replace("[", "")
+                            .replace("]", "")
+                            .replace("'", "")
+                            if defect_ids
+                            else None,
+                            test_parametrize=test_parametrize,
+                            suite_id=suite_id,
+                            test_comments=test_comments,
+                        )
+                    )
             return None
 
     @pytest.hookimpl(tryfirst=True)
@@ -274,21 +367,26 @@ class PyTestRailPlugin(TestrailActions):
                 int(k): v for k, v in json.loads(raw).items()
             }
         else:
-            if not self.testrail_data.testrun_id and not self.testrail_data.testplan_id \
-                    and self.testrail_data.testplan_name:
+            if (
+                not self.testrail_data.testrun_id
+                and not self.testrail_data.testplan_id
+                and self.testrail_data.testplan_name
+            ):
                 self._create_test_plan()
 
     @pytest.hookimpl(trylast=True, hookwrapper=True)
     def pytest_sessionfinish(self, session, exitstatus):
-        """ Publish results in TestRail """
+        """Publish results in TestRail"""
         yield
         if is_xdist_worker(config=session.config):
             # Workers send their results to the controller via workeroutput.
             # Publishing is done only by the controller.
-            session.config.workeroutput['testrail_results'] = self.testrail_data.results
+            session.config.workeroutput["testrail_results"] = self.testrail_data.results
             return
         # Controller or non-xdist run: publish all collected results once.
-        self.publish_results(testrail_data=self.testrail_data, results=self.testrail_data.results)
+        self.publish_results(
+            testrail_data=self.testrail_data, results=self.testrail_data.results
+        )
 
     def pytest_configure(self, config):
         if config.pluginmanager.hasplugin("xdist"):
@@ -296,7 +394,6 @@ class PyTestRailPlugin(TestrailActions):
 
 
 class NodeAction(TestrailActions):
-
     def __init__(self, testrail_data):
         self.testrail_data = testrail_data
         super().__init__(testrail_data=self.testrail_data)
@@ -304,10 +401,13 @@ class NodeAction(TestrailActions):
     def pytest_configure_node(self, node):  # type: ignore
         node.workerinput["test_run_id"] = self.testrail_data.testrun_id
         node.workerinput["actual_suites_with_case_ids"] = json.dumps(
-            {str(k): v for k, v in self.testrail_data.actual_suites_with_case_ids.items()}
+            {
+                str(k): v
+                for k, v in self.testrail_data.actual_suites_with_case_ids.items()
+            }
         )
 
     def pytest_testnodedown(self, node, error):  # type: ignore
         """Collect results from each worker after it finishes."""
-        worker_results = node.workeroutput.get('testrail_results', [])
+        worker_results = node.workeroutput.get("testrail_results", [])
         self.testrail_data.results.extend(worker_results)

--- a/pytest_testrail/testrail_actions.py
+++ b/pytest_testrail/testrail_actions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from collections import defaultdict
 from operator import itemgetter
@@ -34,7 +36,7 @@ class TestrailActions:
         comment: str = "",
         defects=None,
         duration=0,
-        test_parametrize=None,
+        test_parametrize: str | None = None,
         suite_id=0,
         test_comments: list | None = None,
     ):
@@ -44,7 +46,7 @@ class TestrailActions:
         :param suite_id:
         :param test_id:
         :param test_comments: add text from comment fixture
-        :param list test_parametrize: Add test parametrize to test result
+        :param test_parametrize: Add test parametrize to test result
         :param defects: Add defects to test result
         :param int status: status code of test (pass or fail).
         :param comment: None or a failure representation.
@@ -168,9 +170,7 @@ class TestrailActions:
                     )
                 )
 
-    def publish_results(
-        self, testrail_data: TestRailModel = None, results: list = None
-    ):
+    def publish_results(self, results: list | None = None):
         print("[{}] Start publishing".format(TESTRAIL_PREFIX))
 
         if results:
@@ -193,22 +193,44 @@ class TestrailActions:
 
             results_by_run = defaultdict(list)
             if self.testrail_data.testrun_id:
-                test_suite = list(self.testrail_data.plan_entry_storage.keys())[0]
-                for result in results:
-                    if str(result["case_id"]) in tests_list:
-                        if int(result["suite_id"]) == int(test_suite):
-                            results_by_run[
-                                self.testrail_data.plan_entry_storage[
-                                    result["suite_id"]
-                                ]["testrun_id"]
-                            ].append(result)
+                if not self.testrail_data.plan_entry_storage:
+                    print(
+                        "[{}] No plan entries found, publishing all results to testrun {}".format(
+                            TESTRAIL_PREFIX, self.testrail_data.testrun_id
+                        )
+                    )
+                    for result in results:
+                        if str(result["case_id"]) in tests_list:
+                            results_by_run[self.testrail_data.testrun_id].append(result)
+                else:
+                    test_suite = list(self.testrail_data.plan_entry_storage.keys())[0]
+                    for result in results:
+                        if str(result["case_id"]) in tests_list:
+                            if int(result["suite_id"]) == int(test_suite):
+                                results_by_run[
+                                    self.testrail_data.plan_entry_storage[
+                                        result["suite_id"]
+                                    ]["testrun_id"]
+                                ].append(result)
                 self._add_results(
                     self.testrail_data.testrun_id,
-                    results_by_run.get(self.testrail_data.testrun_id),
+                    results_by_run.get(self.testrail_data.testrun_id, []),
                 )
             else:
                 for result in results:
                     if str(result["case_id"]) in tests_list:
+                        if (
+                            result["suite_id"]
+                            not in self.testrail_data.plan_entry_storage
+                        ):
+                            print(
+                                "[{}] Suite ID {} not found in plan entries, skipping case {}".format(
+                                    TESTRAIL_PREFIX,
+                                    result["suite_id"],
+                                    result["case_id"],
+                                )
+                            )
+                            continue
                         results_by_run[
                             self.testrail_data.plan_entry_storage[result["suite_id"]][
                                 "testrun_id"
@@ -356,7 +378,7 @@ class TestrailActions:
     def create_plan(self, project_id, plan_name, milestone_id, description=""):
         data = {
             "name": plan_name,
-            "description": description,
+            "description": description or "",
             "milestone_id": milestone_id,
         }
 
@@ -422,7 +444,7 @@ class TestrailActions:
     def update_testplan_entry(
         self,
         plan_id: int,
-        entry_id: str,
+        entry_id: str | None,
         run_id: int,
         tr_keys: list,
         suite_id: int,

--- a/pytest_testrail/testrail_actions.py
+++ b/pytest_testrail/testrail_actions.py
@@ -44,11 +44,6 @@ class TestrailActions:
         :param testrun_id: Id of the testrun to feed
 
         """
-        # unicode converter for compatibility of python 2 and 3
-        try:
-            converter = unicode
-        except NameError:
-            converter = lambda s, c: str(bytes(s, "utf-8"), c)
         # Results are sorted by 'case_id' and by 'status_id' (worst result at the end)
         # Comment sort by status_id due to issue with pytest-rerun failures,
         # for details refer to issue https://github.com/allankp/pytest-testrail/issues/100
@@ -91,8 +86,7 @@ class TestrailActions:
                 # Indent text to avoid string formatting by TestRail. Limit size of comment.
                 entry['comment'] += u"# Pytest result: #\n"
                 entry['comment'] += u'Log truncated\n...\n' if len(str(comment)) > COMMENT_SIZE_LIMIT else u''
-                entry['comment'] += u"    " + converter(str(comment), "utf-8")[-COMMENT_SIZE_LIMIT:].replace('\n',
-                                                                                                             '\n    ')  # noqa
+                entry['comment'] += u"    " + str(comment)[-COMMENT_SIZE_LIMIT:].replace('\n', '\n    ')  # noqa
             if self.testrail_data.custom_comment:
                 entry['comment'] += self.testrail_data.custom_comment + '\n'
             duration = result.get('duration')

--- a/pytest_testrail/testrail_actions.py
+++ b/pytest_testrail/testrail_actions.py
@@ -3,17 +3,41 @@ from collections import defaultdict
 from operator import itemgetter
 from pytest_testrail.TestrailModel import TestRailModel
 from pytest_testrail.functions import get_case_list, filter_publish_results
-from pytest_testrail.vars import TESTRAIL_PREFIX, TESTRAIL_TEST_STATUS, COMMENT_SIZE_LIMIT, ADD_RESULTS_URL, \
-    ADD_TESTRUN_URL, ADD_TESTPLAN_ENTRY_URL, UPDATE_RUN_URL, GET_TESTRUN_URL, CLOSE_TESTRUN_URL, CLOSE_TESTPLAN_URL, \
-    GET_TESTPLAN_URL, GET_TESTCASES_URL, GET_TESTS_URL, UPDATE_TESTPLAN_ENTRY, ADD_TESTPLAN_URL, GET_SUITES_URL
+from pytest_testrail.vars import (
+    TESTRAIL_PREFIX,
+    TESTRAIL_TEST_STATUS,
+    COMMENT_SIZE_LIMIT,
+    ADD_RESULTS_URL,
+    ADD_TESTRUN_URL,
+    ADD_TESTPLAN_ENTRY_URL,
+    UPDATE_RUN_URL,
+    GET_TESTRUN_URL,
+    CLOSE_TESTRUN_URL,
+    CLOSE_TESTPLAN_URL,
+    GET_TESTPLAN_URL,
+    GET_TESTCASES_URL,
+    GET_TESTS_URL,
+    UPDATE_TESTPLAN_ENTRY,
+    ADD_TESTPLAN_URL,
+    GET_SUITES_URL,
+)
 
 
 class TestrailActions:
     def __init__(self, testrail_data: TestRailModel):
         self.testrail_data = testrail_data
 
-    def add_result(self, test_id, status, comment: str = "", defects=None, duration=0, test_parametrize=None, suite_id=0,
-                   test_comments: list | None = None):
+    def add_result(
+        self,
+        test_id,
+        status,
+        comment: str = "",
+        defects=None,
+        duration=0,
+        test_parametrize=None,
+        suite_id=0,
+        test_comments: list | None = None,
+    ):
         """
         Add a new result to results dict to be submitted at the end.
 
@@ -27,14 +51,14 @@ class TestrailActions:
         :param duration: Time it took to run just the test.
         """
         data = {
-            'case_id': test_id,
-            'status_id': status,
-            'comment': comment,
-            'duration': duration,
-            'defects': defects,
-            'test_parametrize': test_parametrize,
+            "case_id": test_id,
+            "status_id": status,
+            "comment": comment,
+            "duration": duration,
+            "defects": defects,
+            "test_parametrize": test_parametrize,
             "suite_id": suite_id,
-            "test_comments": test_comments or []
+            "test_comments": test_comments or [],
         }
         return data
 
@@ -48,208 +72,317 @@ class TestrailActions:
         # Comment sort by status_id due to issue with pytest-rerun failures,
         # for details refer to issue https://github.com/allankp/pytest-testrail/issues/100
         # self.results.sort(key=itemgetter('status_id'))
-        results.sort(key=itemgetter('case_id'))
+        results.sort(key=itemgetter("case_id"))
 
         # Manage case of "blocked" testcases
         if self.testrail_data.publish_blocked is False:
-            print('[{}] Option "Don\'t publish blocked testcases" activated'.format(TESTRAIL_PREFIX))
+            print(
+                '[{}] Option "Don\'t publish blocked testcases" activated'.format(
+                    TESTRAIL_PREFIX
+                )
+            )
             blocked_tests_list = [
-                test.get('case_id') for test in self.get_tests(testrun_id)
-                if test.get('status_id') == TESTRAIL_TEST_STATUS["blocked"]
+                test.get("case_id")
+                for test in self.get_tests(testrun_id)
+                if test.get("status_id") == TESTRAIL_TEST_STATUS["blocked"]
             ]
-            print('[{}] Blocked testcases excluded: {}'.format(TESTRAIL_PREFIX,
-                                                               ', '.join(str(elt) for elt in blocked_tests_list)))
-            results = [result for result in results if result.get('case_id') not in blocked_tests_list]
+            print(
+                "[{}] Blocked testcases excluded: {}".format(
+                    TESTRAIL_PREFIX, ", ".join(str(elt) for elt in blocked_tests_list)
+                )
+            )
+            results = [
+                result
+                for result in results
+                if result.get("case_id") not in blocked_tests_list
+            ]
 
         # prompt enabling include all test cases from test suite when creating test run
         if self.testrail_data.include_all:
-            print('[{}] Option "Include all testcases from test suite for test run" activated'.format(TESTRAIL_PREFIX))
+            print(
+                '[{}] Option "Include all testcases from test suite for test run" activated'.format(
+                    TESTRAIL_PREFIX
+                )
+            )
 
         # Publish results
         chunks = []
-        data = {'results': []}
+        data = {"results": []}
         for result in results:
-            entry = {'status_id': result['status_id'], 'case_id': result['case_id'], 'defects': result['defects']}
+            entry = {
+                "status_id": result["status_id"],
+                "case_id": result["case_id"],
+                "defects": result["defects"],
+            }
             if self.testrail_data.version:
-                entry['version'] = self.testrail_data.version
-            comment = result.get('comment', '')
-            test_parametrize = result.get('test_parametrize', '')
-            test_comments = result.get('test_comments', [])
-            entry['comment'] = u''
+                entry["version"] = self.testrail_data.version
+            comment = result.get("comment", "")
+            test_parametrize = result.get("test_parametrize", "")
+            test_comments = result.get("test_comments", [])
+            entry["comment"] = ""
             if test_parametrize:
-                entry['comment'] += u"# Test parametrize: #\n"
-                entry['comment'] += str(test_parametrize) + u'\n\n'
+                entry["comment"] += "# Test parametrize: #\n"
+                entry["comment"] += str(test_parametrize) + "\n\n"
             if test_comments:
-                entry['comment'] += u"# Test comments: #\n"
-                entry['comment'] += u'\n'.join(test_comments) + u'\n\n'
-            if comment and result.get('status_id') != 1:
+                entry["comment"] += "# Test comments: #\n"
+                entry["comment"] += "\n".join(test_comments) + "\n\n"
+            if comment and result.get("status_id") != 1:
                 # Indent text to avoid string formatting by TestRail. Limit size of comment.
-                entry['comment'] += u"# Pytest result: #\n"
-                entry['comment'] += u'Log truncated\n...\n' if len(str(comment)) > COMMENT_SIZE_LIMIT else u''
-                entry['comment'] += u"    " + str(comment)[-COMMENT_SIZE_LIMIT:].replace('\n', '\n    ')  # noqa
+                entry["comment"] += "# Pytest result: #\n"
+                entry["comment"] += (
+                    "Log truncated\n...\n"
+                    if len(str(comment)) > COMMENT_SIZE_LIMIT
+                    else ""
+                )
+                entry["comment"] += "    " + str(comment)[-COMMENT_SIZE_LIMIT:].replace(
+                    "\n", "\n    "
+                )  # noqa
             if self.testrail_data.custom_comment:
-                entry['comment'] += self.testrail_data.custom_comment + '\n'
-            duration = result.get('duration')
+                entry["comment"] += self.testrail_data.custom_comment + "\n"
+            duration = result.get("duration")
             if duration:
-                duration = 1 if (duration < 1) else int(round(duration))  # TestRail API doesn't manage milliseconds
-                entry['elapsed'] = str(duration) + 's'
-            data['results'].append(entry)
+                duration = (
+                    1 if (duration < 1) else int(round(duration))
+                )  # TestRail API doesn't manage milliseconds
+                entry["elapsed"] = str(duration) + "s"
+            data["results"].append(entry)
 
             # report data into chunks
             if sys.getsizeof(data.__str__()) > 512 * 1024:
-                chunks.append({'results': data['results']})
-                data['results'] = []
+                chunks.append({"results": data["results"]})
+                data["results"] = []
 
-        chunks.append({'results': data['results']})
+        chunks.append({"results": data["results"]})
 
         for chunk in chunks:
             response = self.testrail_data.client.send_post(
                 ADD_RESULTS_URL.format(testrun_id),
                 chunk,
-                cert_check=self.testrail_data.cert_check
+                cert_check=self.testrail_data.cert_check,
             )
             error = self.testrail_data.client.get_error(response)
             if error:
-                print('[{}] Info: Testcases not published for following reason: "{}"'.format(TESTRAIL_PREFIX, error))
+                print(
+                    '[{}] Info: Testcases not published for following reason: "{}"'.format(
+                        TESTRAIL_PREFIX, error
+                    )
+                )
 
-    def publish_results(self, testrail_data: TestRailModel = None, results: list = None):
-        print('[{}] Start publishing'.format(TESTRAIL_PREFIX))
+    def publish_results(
+        self, testrail_data: TestRailModel = None, results: list = None
+    ):
+        print("[{}] Start publishing".format(TESTRAIL_PREFIX))
 
         if results:
-            results, tests_list = filter_publish_results(results, self.testrail_data.diff_case_ids)
-            print('[{}] Testcases to publish: {}'.format(TESTRAIL_PREFIX, ', '.join(set(tests_list))))
+            results, tests_list = filter_publish_results(
+                results, self.testrail_data.diff_case_ids
+            )
+            print(
+                "[{}] Testcases to publish: {}".format(
+                    TESTRAIL_PREFIX, ", ".join(set(tests_list))
+                )
+            )
 
             if self.testrail_data.diff_case_ids:
-                print(f"[{TESTRAIL_PREFIX}] Not found following testcases in suiteID={self.testrail_data.suite_id}")
-                print(f"[{TESTRAIL_PREFIX}] Testcases will be ignored: {self.testrail_data.diff_case_ids}")
+                print(
+                    f"[{TESTRAIL_PREFIX}] Not found following testcases in suiteID={self.testrail_data.suite_id}"
+                )
+                print(
+                    f"[{TESTRAIL_PREFIX}] Testcases will be ignored: {self.testrail_data.diff_case_ids}"
+                )
 
             results_by_run = defaultdict(list)
             if self.testrail_data.testrun_id:
                 test_suite = list(self.testrail_data.plan_entry_storage.keys())[0]
                 for result in results:
-                    if str(result['case_id']) in tests_list:
-                        if int(result['suite_id']) == int(test_suite):
-                            results_by_run[self.testrail_data.plan_entry_storage[result['suite_id']]['testrun_id']].append(
-                                result)
-                self._add_results(self.testrail_data.testrun_id, results_by_run.get(self.testrail_data.testrun_id))
+                    if str(result["case_id"]) in tests_list:
+                        if int(result["suite_id"]) == int(test_suite):
+                            results_by_run[
+                                self.testrail_data.plan_entry_storage[
+                                    result["suite_id"]
+                                ]["testrun_id"]
+                            ].append(result)
+                self._add_results(
+                    self.testrail_data.testrun_id,
+                    results_by_run.get(self.testrail_data.testrun_id),
+                )
             else:
                 for result in results:
-                    if str(result['case_id']) in tests_list:
-                        results_by_run[self.testrail_data.plan_entry_storage[result['suite_id']]['testrun_id']].append(
-                            result)
+                    if str(result["case_id"]) in tests_list:
+                        results_by_run[
+                            self.testrail_data.plan_entry_storage[result["suite_id"]][
+                                "testrun_id"
+                            ]
+                        ].append(result)
                 for run_id, result in results_by_run.items():
                     self._add_results(run_id, result)
         else:
-            print('[{}] No data published'.format(TESTRAIL_PREFIX))
+            print("[{}] No data published".format(TESTRAIL_PREFIX))
 
         if self.testrail_data.close_on_complete and self.testrail_data.testrun_id:
             self.close_test_run(self.testrail_data.testrun_id)
         elif self.testrail_data.close_on_complete and self.testrail_data.testplan_id:
             self.close_test_plan(self.testrail_data.testplan_id)
-        print('[{}] End publishing'.format(TESTRAIL_PREFIX))
+        print("[{}] End publishing".format(TESTRAIL_PREFIX))
 
         if self.testrail_data.testplan_id:
-            print('[{}] Test Plan ID: {}'.format(TESTRAIL_PREFIX, self.testrail_data.testplan_id))
-            print('[{}] Test Plan URL: {}/index.php?/plans/view/{}'.format(
-                TESTRAIL_PREFIX, self.testrail_data.tr_url, self.testrail_data.testplan_id)
+            print(
+                "[{}] Test Plan ID: {}".format(
+                    TESTRAIL_PREFIX, self.testrail_data.testplan_id
+                )
+            )
+            print(
+                "[{}] Test Plan URL: {}/index.php?/plans/view/{}".format(
+                    TESTRAIL_PREFIX,
+                    self.testrail_data.tr_url,
+                    self.testrail_data.testplan_id,
+                )
             )
         if self.testrail_data.testrun_id:
-            print('[{}] Test Run ID: {}'.format(TESTRAIL_PREFIX, self.testrail_data.testrun_id))
-            print('[{}] Test Run URL: {}/index.php?/runs/view/{}'.format(
-                TESTRAIL_PREFIX, self.testrail_data.tr_url, self.testrail_data.testrun_id)
+            print(
+                "[{}] Test Run ID: {}".format(
+                    TESTRAIL_PREFIX, self.testrail_data.testrun_id
+                )
+            )
+            print(
+                "[{}] Test Run URL: {}/index.php?/runs/view/{}".format(
+                    TESTRAIL_PREFIX,
+                    self.testrail_data.tr_url,
+                    self.testrail_data.testrun_id,
+                )
             )
 
-    def create_test_run(self, assign_user_id, project_id, suite_id, include_all,
-                        testrun_name, tr_keys, milestone_id, description=''):
+    def create_test_run(
+        self,
+        assign_user_id,
+        project_id,
+        suite_id,
+        include_all,
+        testrun_name,
+        tr_keys,
+        milestone_id,
+        description="",
+    ):
         """
         Create testrun with ids collected from markers.
 
         :param tr_keys: collected testrail ids.
         """
         data = {
-            'suite_id': suite_id,
-            'name': testrun_name,
-            'description': description,
-            'assignedto_id': assign_user_id,
-            'include_all': include_all,
-            'case_ids': tr_keys,
-            'milestone_id': milestone_id,
+            "suite_id": suite_id,
+            "name": testrun_name,
+            "description": description,
+            "assignedto_id": assign_user_id,
+            "include_all": include_all,
+            "case_ids": tr_keys,
+            "milestone_id": milestone_id,
         }
 
         response = self.testrail_data.client.send_post(
             ADD_TESTRUN_URL.format(project_id),
             data,
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
         if error:
             print('[{}] Failed to create testrun: "{}"'.format(TESTRAIL_PREFIX, error))
             return 0
         else:
-            self.testrail_data.plan_entry_storage[suite_id] = {"testplan_entry_id": None,
-                                                               "testrun_id": response['id'],
-                                                               "case_ids": tr_keys}
-            print('[{}] New testrun created with name "{}" and ID={}'.format(TESTRAIL_PREFIX,
-                                                                             testrun_name,
-                                                                             self.testrail_data.plan_entry_storage[
-                                                                                 suite_id]["testrun_id"]))
+            self.testrail_data.plan_entry_storage[suite_id] = {
+                "testplan_entry_id": None,
+                "testrun_id": response["id"],
+                "case_ids": tr_keys,
+            }
+            print(
+                '[{}] New testrun created with name "{}" and ID={}'.format(
+                    TESTRAIL_PREFIX,
+                    testrun_name,
+                    self.testrail_data.plan_entry_storage[suite_id]["testrun_id"],
+                )
+            )
             return self.testrail_data.testrun_id
 
-    def create_plan_entry(self, suite_id, testrun_name, assign_user_id, plan_id, include_all, tr_keys, description=''):
+    def create_plan_entry(
+        self,
+        suite_id,
+        testrun_name,
+        assign_user_id,
+        plan_id,
+        include_all,
+        tr_keys,
+        description="",
+    ):
         data = {
-            'suite_id': suite_id,
-            'name': testrun_name,
-            'description': description,
-            'assignedto_id': assign_user_id,
-            'include_all': include_all,
-            'case_ids': tr_keys
+            "suite_id": suite_id,
+            "name": testrun_name,
+            "description": description,
+            "assignedto_id": assign_user_id,
+            "include_all": include_all,
+            "case_ids": tr_keys,
         }
 
         response = self.testrail_data.client.send_post(
             ADD_TESTPLAN_ENTRY_URL.format(plan_id),
             data,
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
         if error:
-            print('[{}] Failed to create testplan entry: "{}"'.format(TESTRAIL_PREFIX, error))
+            print(
+                '[{}] Failed to create testplan entry: "{}"'.format(
+                    TESTRAIL_PREFIX, error
+                )
+            )
             return 0
         else:
-            self.testrail_data.plan_entry_storage[suite_id] = {"testplan_entry_id": response['id'],
-                                                               "testrun_id": response['runs'][0]['id'],
-                                                               "case_ids": tr_keys}
-            print('[{}] New TestPlan entry created with name "{}" and ID={}, entry_id={}'
-                  .format(TESTRAIL_PREFIX,
-                          testrun_name,
-                          self.testrail_data.plan_entry_storage[suite_id]["testrun_id"],
-                          self.testrail_data.plan_entry_storage[suite_id]["testplan_entry_id"]))
+            self.testrail_data.plan_entry_storage[suite_id] = {
+                "testplan_entry_id": response["id"],
+                "testrun_id": response["runs"][0]["id"],
+                "case_ids": tr_keys,
+            }
+            print(
+                '[{}] New TestPlan entry created with name "{}" and ID={}, entry_id={}'.format(
+                    TESTRAIL_PREFIX,
+                    testrun_name,
+                    self.testrail_data.plan_entry_storage[suite_id]["testrun_id"],
+                    self.testrail_data.plan_entry_storage[suite_id][
+                        "testplan_entry_id"
+                    ],
+                )
+            )
 
             return self.testrail_data.plan_entry_storage[suite_id]["testrun_id"]
 
-    def create_plan(self, project_id, plan_name, milestone_id, description=''):
+    def create_plan(self, project_id, plan_name, milestone_id, description=""):
         data = {
-            'name': plan_name,
-            'description': description,
-            'milestone_id': milestone_id,
+            "name": plan_name,
+            "description": description,
+            "milestone_id": milestone_id,
         }
 
         response = self.testrail_data.client.send_post(
             ADD_TESTPLAN_URL.format(project_id),
             data,
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
         if error:
-            print('[{}] Failed to create test plan: "{}"'.format(TESTRAIL_PREFIX, error))
+            print(
+                '[{}] Failed to create test plan: "{}"'.format(TESTRAIL_PREFIX, error)
+            )
             return 0
         else:
-            self.testrail_data.testplan_id = response['id']
-            print('[{}] New test plan created with name "{}" and ID={}'.format(TESTRAIL_PREFIX,
-                                                                               plan_name,
-                                                                               self.testrail_data.testplan_id))
+            self.testrail_data.testplan_id = response["id"]
+            print(
+                '[{}] New test plan created with name "{}" and ID={}'.format(
+                    TESTRAIL_PREFIX, plan_name, self.testrail_data.testplan_id
+                )
+            )
             return self.testrail_data.testplan_id
 
-    def update_testrun(self, testrun_id: int, tr_keys: list, suite_id: int, save_previous: bool = True) -> None:
+    def update_testrun(
+        self, testrun_id: int, tr_keys: list, suite_id: int, save_previous: bool = True
+    ) -> None:
         """
         Updates an existing test run
         :param testrun_id: testrun id
@@ -262,54 +395,68 @@ class TestrailActions:
             current_tests = get_case_list(self.get_tests(run_id=testrun_id))
 
         data = {
-            'case_ids': list(set(tr_keys + current_tests)),
-            'include_all': self.testrail_data.include_all
+            "case_ids": list(set(tr_keys + current_tests)),
+            "include_all": self.testrail_data.include_all,
         }
 
         response = self.testrail_data.client.send_post(
             UPDATE_RUN_URL.format(testrun_id),
             data,
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
-        self.testrail_data.plan_entry_storage[suite_id] = {"testplan_entry_id": None,
-                                                           "testrun_id": testrun_id,
-                                                           "case_ids": list(set(tr_keys + current_tests))}
+        self.testrail_data.plan_entry_storage[suite_id] = {
+            "testplan_entry_id": None,
+            "testrun_id": testrun_id,
+            "case_ids": list(set(tr_keys + current_tests)),
+        }
         if error:
             print('[{}] Failed to update testrun: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            print('[{}] Testrun updated with name "{}" and ID={}'.format(TESTRAIL_PREFIX,
-                                                                         self.testrail_data.testrun_name,
-                                                                         testrun_id))
+            print(
+                '[{}] Testrun updated with name "{}" and ID={}'.format(
+                    TESTRAIL_PREFIX, self.testrail_data.testrun_name, testrun_id
+                )
+            )
 
-    def update_testplan_entry(self, plan_id: int, entry_id: str, run_id: int, tr_keys: list, suite_id: int,
-                              save_previous: bool = True) -> None:
+    def update_testplan_entry(
+        self,
+        plan_id: int,
+        entry_id: str,
+        run_id: int,
+        tr_keys: list,
+        suite_id: int,
+        save_previous: bool = True,
+    ) -> None:
         current_tests = []
 
         if save_previous:
             current_tests = get_case_list(self.get_tests(run_id=run_id))
 
         data = {
-            'case_ids': list(set(tr_keys + current_tests)),
-            'include_all': self.testrail_data.include_all
+            "case_ids": list(set(tr_keys + current_tests)),
+            "include_all": self.testrail_data.include_all,
         }
 
         response = self.testrail_data.client.send_post(
             UPDATE_TESTPLAN_ENTRY.format(plan_id, entry_id),
             data,
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
-        self.testrail_data.plan_entry_storage[suite_id] = {"testplan_entry_id": entry_id,
-                                                           "testrun_id": run_id,
-                                                           "case_ids": list(set(tr_keys + current_tests))}
+        self.testrail_data.plan_entry_storage[suite_id] = {
+            "testplan_entry_id": entry_id,
+            "testrun_id": run_id,
+            "case_ids": list(set(tr_keys + current_tests)),
+        }
         if error:
             print('[{}] Failed to update testrun: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            print('[{}] Testrun updated with name "{}" and ID={}, entry_id={}'.format(TESTRAIL_PREFIX,
-                                                                                      self.testrail_data.testrun_name,
-                                                                                      run_id,
-                                                                                      entry_id))
+            print(
+                '[{}] Testrun updated with name "{}" and ID={}, entry_id={}'.format(
+                    TESTRAIL_PREFIX, self.testrail_data.testrun_name, run_id, entry_id
+                )
+            )
 
     def is_testrun_available(self):
         """
@@ -319,14 +466,16 @@ class TestrailActions:
         """
         response = self.testrail_data.client.send_get(
             GET_TESTRUN_URL.format(self.testrail_data.testrun_id),
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
         if error:
-            print('[{}] Failed to retrieve testrun: "{}"'.format(TESTRAIL_PREFIX, error))
+            print(
+                '[{}] Failed to retrieve testrun: "{}"'.format(TESTRAIL_PREFIX, error)
+            )
             return False
 
-        return response['is_completed'] is False
+        return response["is_completed"] is False
 
     def close_test_run(self, testrun_id):
         """
@@ -336,13 +485,17 @@ class TestrailActions:
         response = self.testrail_data.client.send_post(
             CLOSE_TESTRUN_URL.format(testrun_id),
             data={},
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
         if error:
             print('[{}] Failed to close test run: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            print('[{}] Test run with ID={} was closed'.format(TESTRAIL_PREFIX, self.testrail_data.testrun_id))
+            print(
+                "[{}] Test run with ID={} was closed".format(
+                    TESTRAIL_PREFIX, self.testrail_data.testrun_id
+                )
+            )
 
     def close_test_plan(self, testplan_id: int):
         """
@@ -352,13 +505,17 @@ class TestrailActions:
         response = self.testrail_data.client.send_post(
             CLOSE_TESTPLAN_URL.format(testplan_id),
             data={},
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
         if error:
             print('[{}] Failed to close test plan: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            print('[{}] Test plan with ID={} was closed'.format(TESTRAIL_PREFIX, self.testrail_data.testplan_id))
+            print(
+                "[{}] Test plan with ID={} was closed".format(
+                    TESTRAIL_PREFIX, self.testrail_data.testplan_id
+                )
+            )
 
     def get_cases(self, project_id, suit_id):
         """
@@ -366,11 +523,13 @@ class TestrailActions:
         """
         response = self.testrail_data.client.send_get(
             GET_TESTCASES_URL.format(project_id, suit_id),
-            cert_check=self.testrail_data.cert_check
+            cert_check=self.testrail_data.cert_check,
         )
         error = self.testrail_data.client.get_error(response)
         if error:
-            print(f'[{TESTRAIL_PREFIX}] Failed to get tests: "{error} for suite: {suit_id}"')
+            print(
+                f'[{TESTRAIL_PREFIX}] Failed to get tests: "{error} for suite: {suit_id}"'
+            )
             return []
         return response
 
@@ -379,12 +538,13 @@ class TestrailActions:
         :return: The list of suite_ids
         """
         response = self.testrail_data.client.send_get(
-            GET_SUITES_URL.format(project_id),
-            cert_check=self.testrail_data.cert_check
+            GET_SUITES_URL.format(project_id), cert_check=self.testrail_data.cert_check
         )
         error = self.testrail_data.client.get_error(response)
         if error:
-            print(f'[{TESTRAIL_PREFIX}] Failed to get suites: "{error} for project id: {project_id}"')
+            print(
+                f'[{TESTRAIL_PREFIX}] Failed to get suites: "{error} for project id: {project_id}"'
+            )
             return []
         return response
 
@@ -394,8 +554,7 @@ class TestrailActions:
 
         """
         response = self.testrail_data.client.send_get(
-            GET_TESTS_URL.format(run_id),
-            cert_check=self.testrail_data.cert_check
+            GET_TESTS_URL.format(run_id), cert_check=self.testrail_data.cert_check
         )
         error = self.testrail_data.client.get_error(response)
         if error:
@@ -409,8 +568,7 @@ class TestrailActions:
 
         """
         response = self.testrail_data.client.send_get(
-            GET_TESTPLAN_URL.format(plan_id),
-            cert_check=self.testrail_data.cert_check
+            GET_TESTPLAN_URL.format(plan_id), cert_check=self.testrail_data.cert_check
         )
         error = self.testrail_data.client.get_error(response)
         if error:
@@ -422,8 +580,7 @@ class TestrailActions:
         Return info
         """
         response = self.testrail_data.client.send_get(
-            GET_TESTRUN_URL.format(run_id),
-            cert_check=self.testrail_data.cert_check
+            GET_TESTRUN_URL.format(run_id), cert_check=self.testrail_data.cert_check
         )
         error = self.testrail_data.client.get_error(response)
         if error:
@@ -436,10 +593,10 @@ class TestrailActions:
 
         """
         response = self.get_plan(plan_id)
-        for entry in response['entries']:
-            for run in entry['runs']:
-                if str(run['id']) == run_id:
-                    self.testrail_data.testplan_entry_id = entry['id']
+        for entry in response["entries"]:
+            for run in entry["runs"]:
+                if str(run["id"]) == run_id:
+                    self.testrail_data.testplan_entry_id = entry["id"]
                     return self.testrail_data.testplan_entry_id
         return None
 
@@ -450,10 +607,10 @@ class TestrailActions:
         """
         testruns_list = []
         response = self.get_plan(plan_id)
-        for entry in response['entries']:
-            for run in entry['runs']:
-                if not run['is_completed']:
-                    testruns_list.append(run['id'])
+        for entry in response["entries"]:
+            for run in entry["runs"]:
+                if not run["is_completed"]:
+                    testruns_list.append(run["id"])
         return testruns_list
 
     def is_testplan_available(self):
@@ -465,7 +622,9 @@ class TestrailActions:
         response = self.get_plan(self.testrail_data.testplan_id)
         error = self.testrail_data.client.get_error(response)
         if error:
-            print('[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error))
+            print(
+                '[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error)
+            )
             return False
 
-        return response['is_completed'] is False
+        return response["is_completed"] is False

--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -18,7 +18,7 @@ from urllib.parse import urljoin
 
 class APIClient:
     def __init__(self, base_url, user, password, **kwargs):
-        '''
+        """
         Instantiate the APIClient class.
 
         :param base_url: The same TestRail address for the API client you also use to access TestRail with your web
@@ -36,18 +36,20 @@ class APIClient:
         :param timeout: (optional) How many seconds to wait for the server to send data before giving up, as a float,
             or a :ref:`(connect timeout, read timeout) <timeouts>` tuple.
         :type timeout: float or tuple
-        '''
+        """
         self.user = user
         self.password = password
-        self._url = urljoin(base_url, 'index.php?/api/v2/')
-        self.headers = kwargs.get('headers', {'Content-Type': 'application/json'})
-        self.cert_check = kwargs.get('cert_check', True)
-        self.timeout = kwargs.get('timeout', 10.0)
+        self._url = urljoin(base_url, "index.php?/api/v2/")
+        self.headers = kwargs.get("headers", {"Content-Type": "application/json"})
+        self.cert_check = kwargs.get("cert_check", True)
+        self.timeout = kwargs.get("timeout", 10.0)
         if self.timeout is not None:
-            self.timeout = isinstance(self.timeout, float) if False else float(self.timeout)
+            self.timeout = (
+                isinstance(self.timeout, float) if False else float(self.timeout)
+            )
 
     def send_get(self, uri, **kwargs):
-        '''
+        """
         Send GET
 
         Issues a GET request (read) against the API and returns the result (as Python dict).
@@ -62,20 +64,20 @@ class APIClient:
         :param timeout: (optional) How many seconds to wait for the server to send data before giving up, as a float,
             or a :ref:`(connect timeout, read timeout) <timeouts>` tuple.
         :type timeout: float or tuple
-        '''
-        cert_check = kwargs.get('cert_check', self.cert_check)
-        headers = kwargs.get('headers', self.headers)
+        """
+        cert_check = kwargs.get("cert_check", self.cert_check)
+        headers = kwargs.get("headers", self.headers)
         url = self._url + uri
         r = requests.get(
             url,
             auth=(self.user, self.password),
             headers=headers,
             verify=cert_check,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
 
         if r.status_code == 429:  # Too many requests
-            pause = int(r.headers.get('Retry-After', 60))
+            pause = int(r.headers.get("Retry-After", 60))
             print("Too many requests: pause for {}s".format(pause))
             time.sleep(pause)
             return self.send_get(uri, **kwargs)
@@ -83,7 +85,7 @@ class APIClient:
             return r.json()
 
     def send_post(self, uri, data, **kwargs):
-        '''
+        """
         Send POST
 
         Issues a POST request (write) against the API and returns the result (as Python dict).
@@ -100,9 +102,9 @@ class APIClient:
         :param timeout: (optional) How many seconds to wait for the server to send data before giving up, as a float,
             or a :ref:`(connect timeout, read timeout) <timeouts>` tuple.
         :type timeout: float or tuple
-        '''
-        cert_check = kwargs.get('cert_check', self.cert_check)
-        headers = kwargs.get('headers', self.headers)
+        """
+        cert_check = kwargs.get("cert_check", self.cert_check)
+        headers = kwargs.get("headers", self.headers)
         url = self._url + uri
         r = requests.post(
             url,
@@ -110,11 +112,11 @@ class APIClient:
             headers=headers,
             json=data,
             verify=cert_check,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
 
         if r.status_code == 429:  # Too many requests
-            pause = int(r.headers.get('Retry-After', 60))
+            pause = int(r.headers.get("Retry-After", 60))
             print("Too many requests: pause for {}s".format(pause))
             time.sleep(pause)
             return self.send_post(uri, data, **kwargs)
@@ -125,11 +127,11 @@ class APIClient:
 
     @staticmethod
     def get_error(json_response):
-        """ Extract error contained in a API response.
-            If no error occured, return None
+        """Extract error contained in a API response.
+        If no error occured, return None
 
-            :param json_response: json response of request
-            :return: String of the error
+        :param json_response: json response of request
+        :return: String of the error
         """
-        if 'error' in json_response and json_response['error']:
-            return json_response['error']
+        if "error" in json_response and json_response["error"]:
+            return json_response["error"]

--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -11,14 +11,9 @@
 # Copyright Gurock Software GmbH. See license.md for details.
 #
 
-import sys
 import requests
 import time
-
-if sys.version_info.major == 2:
-    from urlparse import urljoin
-else:
-    from urllib.parse import urljoin
+from urllib.parse import urljoin
 
 
 class APIClient:

--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -17,7 +17,7 @@ from urllib.parse import urljoin
 
 
 class APIClient:
-    def __init__(self, base_url, user, password, **kwargs):
+    def __init__(self, base_url: str, user: str, password: str, **kwargs):
         """
         Instantiate the APIClient class.
 

--- a/pytest_testrail/vars.py
+++ b/pytest_testrail/vars.py
@@ -4,7 +4,7 @@ TESTRAIL_TEST_STATUS = {
     "blocked": 2,
     "untested": 3,
     "retest": 4,
-    "failed": 5
+    "failed": 5,
 }
 
 PYTEST_TO_TESTRAIL_STATUS = {
@@ -13,23 +13,23 @@ PYTEST_TO_TESTRAIL_STATUS = {
     "skipped": TESTRAIL_TEST_STATUS["blocked"],
 }
 
-DT_FORMAT = '%d-%m-%Y %H:%M:%S'
+DT_FORMAT = "%d-%m-%Y %H:%M:%S"
 
-TESTRAIL_PREFIX = 'testrail'
-TESTRAIL_DEFECTS_PREFIX = 'testrail_defects'
+TESTRAIL_PREFIX = "testrail"
+TESTRAIL_DEFECTS_PREFIX = "testrail_defects"
 TESTRAIL_SUITES_PREFIX = "testrail_suites"
-ADD_RESULTS_URL = 'add_results_for_cases/{}'
-ADD_TESTRUN_URL = 'add_run/{}'
-ADD_TESTPLAN_ENTRY_URL = 'add_plan_entry/{}'
-ADD_TESTPLAN_URL = 'add_plan/{}'
-CLOSE_TESTRUN_URL = 'close_run/{}'
-CLOSE_TESTPLAN_URL = 'close_plan/{}'
-GET_TESTRUN_URL = 'get_run/{}'
-GET_TESTPLAN_URL = 'get_plan/{}'
-GET_TESTS_URL = 'get_tests/{}'
-GET_TESTCASES_URL = 'get_cases/{}&suite_id={}&limit=99999'
-GET_SUITES_URL = 'get_suites/{}'
-UPDATE_RUN_URL = 'update_run/{}'
+ADD_RESULTS_URL = "add_results_for_cases/{}"
+ADD_TESTRUN_URL = "add_run/{}"
+ADD_TESTPLAN_ENTRY_URL = "add_plan_entry/{}"
+ADD_TESTPLAN_URL = "add_plan/{}"
+CLOSE_TESTRUN_URL = "close_run/{}"
+CLOSE_TESTPLAN_URL = "close_plan/{}"
+GET_TESTRUN_URL = "get_run/{}"
+GET_TESTPLAN_URL = "get_plan/{}"
+GET_TESTS_URL = "get_tests/{}"
+GET_TESTCASES_URL = "get_cases/{}&suite_id={}&limit=99999"
+GET_SUITES_URL = "get_suites/{}"
+UPDATE_RUN_URL = "update_run/{}"
 UPDATE_TESTPLAN_ENTRY = "/update_plan_entry/{}/{}"
 
 COMMENT_SIZE_LIMIT = 4000

--- a/setup.py
+++ b/setup.py
@@ -7,22 +7,22 @@ def read_file(fname):
 
 
 setup(
-    name='pytest-testrail',
-    description='pytest plugin for creating TestRail runs and adding results',
-    long_description=read_file('README.rst'),
-    version='3.0.7',
-    author='Allan Kilpatrick',
-    author_email='allanklp@gmail.com',
-    url='http://github.com/allankp/pytest-testrail/',
-    python_requires='>=3.6',
+    name="pytest-testrail",
+    description="pytest plugin for creating TestRail runs and adding results",
+    long_description=read_file("README.rst"),
+    version="3.0.7",
+    author="Allan Kilpatrick",
+    author_email="allanklp@gmail.com",
+    url="http://github.com/allankp/pytest-testrail/",
+    python_requires=">=3.6",
     packages=[
-        'pytest_testrail',
+        "pytest_testrail",
     ],
-    package_dir={'pytest_testrail': 'pytest_testrail'},
+    package_dir={"pytest_testrail": "pytest_testrail"},
     install_requires=[
-        'pytest>=3.10',
-        'requests>=2.20.0',
+        "pytest>=3.10",
+        "requests>=2.20.0",
     ],
     include_package_data=True,
-    entry_points={'pytest11': ['pytest-testrail = pytest_testrail.conftest']},
+    entry_points={"pytest11": ["pytest-testrail = pytest_testrail.conftest"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
     url='http://github.com/allankp/pytest-testrail/',
+    python_requires='>=3.6',
     packages=[
         'pytest_testrail',
     ],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name='pytest-testrail',
     description='pytest plugin for creating TestRail runs and adding results',
     long_description=read_file('README.rst'),
-    version='3.0.6',
+    version='3.0.7',
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
     url='http://github.com/allankp/pytest-testrail/',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 from datetime import datetime
 from freezegun import freeze_time
-from mock import call, create_autospec
+from mock import call, create_autospec, MagicMock
 import pytest
 from pytest_testrail import vars, plugin
 from pytest_testrail.plugin import PyTestRailPlugin
@@ -104,113 +104,88 @@ def test_get_testrail_keys(pytest_test_items, testdir):
 
 def test_add_result(tr_plugin):
     status = TESTRAIL_TEST_STATUS["passed"]
-    tr_plugin.add_result([1, 2], status, comment='ERROR!', duration=3600, defects='PF-456')
+    result = tr_plugin.add_result(1, status, comment='ERROR!', duration=3600, defects='PF-456')
 
-    expected_results = [
-        {
-            'case_id': 1,
-            'status_id': status,
-            'comment': "ERROR!",
-            'duration': 3600,
-            'defects': 'PF-456',
-            'test_parametrize': None
-        },
-        {
-            'case_id': 2,
-            'status_id': status,
-            'comment': "ERROR!",
-            'duration': 3600,
-            'defects': 'PF-456',
-            'test_parametrize': None
-        }
-    ]
-
-    assert tr_plugin.results == expected_results
+    assert result == {
+        'case_id': 1,
+        'status_id': status,
+        'comment': 'ERROR!',
+        'duration': 3600,
+        'defects': 'PF-456',
+        'test_parametrize': None,
+        'suite_id': 0,
+        'test_comments': [],
+    }
 
 
-def test_pytest_runtest_makereport(pytest_test_items, tr_plugin, testdir):
-    # --------------------------------
-    # This part of code is a little tricky: it fakes the execution of pytest_runtest_makereport (generator)
-    # by artificially send a stub object (Outcome)
-    class Outcome:
-        def __init__(self):
-            testdir.makepyfile(PYTEST_FILE)
-            self.result = testdir.runpytest()
-            setattr(self.result, "when", "call")
-            setattr(self.result, "longrepr", "An error")
-            setattr(self.result, "outcome", "failed")
-            self.result.duration = 2
+def test_pytest_runtest_makereport(pytest_test_items, tr_plugin):
+    rep = MagicMock()
+    rep.sections = []
+    rep.when = "call"
+    rep.failed = True
+    rep.longreprtext = "An error"
+    rep.skipped = False
+    rep.duration = 2
+    rep.outcome = "failed"
 
+    class FakeOutcome:
         def get_result(self):
-            return self.result
+            return rep
 
-    outcome = Outcome()
+    tr_plugin.testrail_data.actual_suites_with_case_ids = {SUITE_ID: [1234, 5678]}
+
     f = tr_plugin.pytest_runtest_makereport(pytest_test_items[0], None)
-    f.send(None)
+    next(f)
     try:
-        f.send(outcome)
+        f.send(FakeOutcome())
     except StopIteration:
         pass
-    # --------------------------------
 
-    expected_results = [
-        {
-            'case_id': 1234,
-            'status_id': TESTRAIL_TEST_STATUS["failed"],
-            'comment': "An error",
-            'duration': 2,
-            'defects': None,
-            'test_parametrize': None
-        },
-        {
-            'case_id': 5678,
-            'status_id': TESTRAIL_TEST_STATUS["failed"],
-            'comment': "An error",
-            'duration': 2,
-            'defects': None,
-            'test_parametrize': None
-        }
-    ]
-    assert tr_plugin.results == expected_results
+    results = tr_plugin.testrail_data.results
+    assert len(results) == 2
+    case_ids = {r['case_id'] for r in results}
+    assert case_ids == {1234, 5678}
+    for r in results:
+        assert r['status_id'] == TESTRAIL_TEST_STATUS["failed"]
+        assert r['comment'] == "An error"
+        assert r['duration'] == 2
 
 
 def test_pytest_sessionfinish(api_client, tr_plugin):
-    tr_plugin.results = [
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'duration': 2.6, 'defects':'PF-516'},
-        {
-            'case_id': 5678,
-            'status_id': TESTRAIL_TEST_STATUS["blocked"],
-            'comment': "An error",
-            'duration': 0.1,
-            'defects':None
-        },
-        {
-            'case_id': 1234,
-            'status_id': TESTRAIL_TEST_STATUS["passed"],
-            'duration': 2.6,
-            'defects': ['PF-517', 'PF-113']
-        }
+    tr_plugin.testrail_data.results = [
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'duration': 2.6, 'defects': 'PF-516',
+         'comment': '', 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID},
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'comment': "An error",
+         'duration': 0.1, 'defects': None, 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'duration': 2.6,
+         'defects': ['PF-517', 'PF-113'], 'comment': '', 'test_parametrize': None, 'test_comments': [],
+         'suite_id': SUITE_ID},
     ]
-    tr_plugin.testrun_id = 10
+    tr_plugin.testrail_data.testrun_id = 10
+    tr_plugin.testrail_data.diff_case_ids = []
+    tr_plugin.testrail_data.plan_entry_storage = {
+        SUITE_ID: {'testrun_id': 10, 'testplan_entry_id': None, 'case_ids': [1234, 5678]}
+    }
+    api_client.send_post.return_value = {}
 
-    tr_plugin.pytest_sessionfinish(None, 0)
+    tr_plugin.publish_results(testrail_data=tr_plugin.testrail_data, results=tr_plugin.testrail_data.results)
 
     expected_data = {'results': [
         {
             'case_id': 1234,
             'status_id': TESTRAIL_TEST_STATUS["failed"],
-            'defects':'PF-516',
+            'defects': 'PF-516',
             'version': '1.0.0.0',
             'elapsed': '3s',
-            'comment': CUSTOM_COMMENT
+            'comment': '{}\n'.format(CUSTOM_COMMENT),
         },
         {
             'case_id': 1234,
             'status_id': TESTRAIL_TEST_STATUS["passed"],
-            'defects':['PF-517', 'PF-113'],
+            'defects': ['PF-517', 'PF-113'],
             'version': '1.0.0.0',
             'elapsed': '3s',
-            'comment': CUSTOM_COMMENT
+            'comment': '{}\n'.format(CUSTOM_COMMENT),
         },
         {
             'case_id': 5678,
@@ -218,52 +193,51 @@ def test_pytest_sessionfinish(api_client, tr_plugin):
             'defects': None,
             'version': '1.0.0.0',
             'elapsed': '1s',
-            'comment': u'{}\n# Pytest result: #\n    An error'.format(CUSTOM_COMMENT)}
+            'comment': u'# Pytest result: #\n    An error{}\n'.format(CUSTOM_COMMENT),
+        },
     ]}
 
-    api_client.send_post.assert_any_call(vars.ADD_RESULTS_URL.format(tr_plugin.testrun_id), expected_data,
-                                         cert_check=True)
+    api_client.send_post.assert_any_call(vars.ADD_RESULTS_URL.format(10), expected_data, cert_check=True)
 
 
 def test_pytest_sessionfinish_testplan(api_client, tr_plugin):
-    tr_plugin.results = [
-        {
-            'case_id': 5678,
-            'status_id': TESTRAIL_TEST_STATUS["blocked"],
-            'comment': "An error",
-            'duration': 0.1,
-            'defects':None,
-        },
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'duration': 2.6, 'defects':None}
+    SUITE_ID_2 = 2
+    tr_plugin.testrail_data.results = [
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'comment': "An error",
+         'duration': 0.1, 'defects': None, 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID_2},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'duration': 2.6,
+         'defects': None, 'comment': '', 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID},
     ]
-    tr_plugin.testplan_id = 100
-    tr_plugin.testrun_id = 0
+    tr_plugin.testrail_data.testrun_id = 0
+    tr_plugin.testrail_data.testplan_id = 100
+    tr_plugin.testrail_data.diff_case_ids = []
+    tr_plugin.testrail_data.plan_entry_storage = {
+        SUITE_ID: {'testrun_id': 59, 'testplan_entry_id': 'ce2f3c8f-9899-47b9-a6da-db59a66fb794', 'case_ids': [1234]},
+        SUITE_ID_2: {'testrun_id': 61, 'testplan_entry_id': '775740ff-1ba3-4313-a9df-3acd9d5ef967', 'case_ids': [5678]},
+    }
+    api_client.send_post.return_value = {}
 
-    api_client.send_get.return_value = TESTPLAN
-    tr_plugin.pytest_sessionfinish(None, 0)
-    expected_data = {'results': [
-        {
-            'case_id': 1234,
-            'status_id': TESTRAIL_TEST_STATUS["passed"],
-            'version': '1.0.0.0',
-            'elapsed': '3s',
-            'defects':None,
-            'comment': CUSTOM_COMMENT
-        },
-        {
-            'case_id': 5678,
-            'status_id': TESTRAIL_TEST_STATUS["blocked"],
-            'version': '1.0.0.0',
-            'elapsed': '1s',
-            'defects':None,
-            'comment': u'{}\n# Pytest result: #\n    An error'.format(CUSTOM_COMMENT)}
-    ]}
-    print(api_client.send_post.call_args_list)
+    tr_plugin.publish_results(testrail_data=tr_plugin.testrail_data, results=tr_plugin.testrail_data.results)
 
-    api_client.send_post.assert_any_call(vars.ADD_RESULTS_URL.format(59, 1234),
-                                         expected_data, cert_check=True)
-    api_client.send_post.assert_any_call(vars.ADD_RESULTS_URL.format(61, 5678),
-                                         expected_data, cert_check=True)
+    expected_data_59 = {'results': [{
+        'case_id': 1234,
+        'status_id': TESTRAIL_TEST_STATUS["passed"],
+        'defects': None,
+        'version': '1.0.0.0',
+        'elapsed': '3s',
+        'comment': '{}\n'.format(CUSTOM_COMMENT),
+    }]}
+    expected_data_61 = {'results': [{
+        'case_id': 5678,
+        'status_id': TESTRAIL_TEST_STATUS["blocked"],
+        'defects': None,
+        'version': '1.0.0.0',
+        'elapsed': '1s',
+        'comment': u'# Pytest result: #\n    An error{}\n'.format(CUSTOM_COMMENT),
+    }]}
+
+    api_client.send_post.assert_any_call(vars.ADD_RESULTS_URL.format(59), expected_data_59, cert_check=True)
+    api_client.send_post.assert_any_call(vars.ADD_RESULTS_URL.format(61), expected_data_61, cert_check=True)
 
 
 @pytest.mark.parametrize('include_all', [True, False])
@@ -324,80 +298,82 @@ def test_get_available_testruns(api_client, tr_plugin):
 
 
 def test_close_test_run(api_client, tr_plugin):
-    tr_plugin.results = [
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'duration': 2.6, 'defects':None},
-        {
-            'case_id': 5678,
-            'status_id': TESTRAIL_TEST_STATUS["blocked"],
-            'comment': "An error",
-            'duration': 0.1,
-            'defects':None
-        },
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'duration': 2.6, 'defects':None}
+    tr_plugin.testrail_data.results = [
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'duration': 2.6, 'defects': None,
+         'comment': '', 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID},
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'comment': "An error",
+         'duration': 0.1, 'defects': None, 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'duration': 2.6, 'defects': None,
+         'comment': '', 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID},
     ]
-    tr_plugin.testrun_id = 10
-    tr_plugin.close_on_complete = True
-    tr_plugin.pytest_sessionfinish(None, 0)
+    tr_plugin.testrail_data.testrun_id = 10
+    tr_plugin.testrail_data.close_on_complete = True
+    tr_plugin.testrail_data.diff_case_ids = []
+    tr_plugin.testrail_data.plan_entry_storage = {
+        SUITE_ID: {'testrun_id': 10, 'testplan_entry_id': None, 'case_ids': [1234, 5678]}
+    }
+    api_client.send_post.return_value = {}
 
-    expected_uri = vars.CLOSE_TESTRUN_URL.format(tr_plugin.testrun_id)
-    api_client.send_post.call_args_list[1] = call(expected_uri, {}, cert_check=True)
+    tr_plugin.publish_results(testrail_data=tr_plugin.testrail_data, results=tr_plugin.testrail_data.results)
+
+    api_client.send_post.assert_any_call(vars.CLOSE_TESTRUN_URL.format(10), data={}, cert_check=True)
 
 
 def test_close_test_plan(api_client, tr_plugin):
-    tr_plugin.results = [
-        {
-            'case_id': 5678,
-            'status_id': TESTRAIL_TEST_STATUS["blocked"],
-            'comment': "An error",
-            'duration': 0.1,
-            'defects':None
-        },
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'duration': 2.6, 'defects':None}
+    tr_plugin.testrail_data.results = [
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'comment': "An error",
+         'duration': 0.1, 'defects': None, 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'duration': 2.6, 'defects': None,
+         'comment': '', 'test_parametrize': None, 'test_comments': [], 'suite_id': SUITE_ID},
     ]
-    tr_plugin.testplan_id = 100
-    tr_plugin.testrun_id = 0
-    tr_plugin.close_on_complete = True
+    tr_plugin.testrail_data.testplan_id = 100
+    tr_plugin.testrail_data.testrun_id = 0
+    tr_plugin.testrail_data.close_on_complete = True
+    tr_plugin.testrail_data.diff_case_ids = []
+    tr_plugin.testrail_data.plan_entry_storage = {
+        SUITE_ID: {'testrun_id': 10, 'testplan_entry_id': None, 'case_ids': [1234, 5678]}
+    }
+    api_client.send_post.return_value = {}
 
-    api_client.send_get.return_value = TESTPLAN
-    tr_plugin.pytest_sessionfinish(None, 0)
+    tr_plugin.publish_results(testrail_data=tr_plugin.testrail_data, results=tr_plugin.testrail_data.results)
 
-    expected_uri = vars.CLOSE_TESTPLAN_URL.format(tr_plugin.testplan_id)
-    api_client.send_post.call_args_list[1] = call(expected_uri, {}, cert_check=True)
+    api_client.send_post.assert_any_call(vars.CLOSE_TESTPLAN_URL.format(100), data={}, cert_check=True)
 
 
 def test_dont_publish_blocked(api_client):
-    """ Case: one test is blocked"""
+    """ Case: one test is blocked in TestRail — its result should not be published """
     my_plugin = PyTestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, False, True, TR_NAME,
                                  version='1.0.0.0',
                                  publish_blocked=False
                                  )
 
-    my_plugin.results = [
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'defects': None},
-        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects': None}
+    results = [
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'defects': None,
+         'comment': '', 'duration': 0, 'test_parametrize': None, 'test_comments': []},
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects': None,
+         'comment': '', 'duration': 0, 'test_parametrize': None, 'test_comments': []},
     ]
-    my_plugin.testrun_id = 10
 
     api_client.send_get.return_value = [
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'defects':None},
-        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects':None}
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["blocked"]},
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["passed"]},
     ]
+    api_client.send_post.return_value = {}
 
-    my_plugin.pytest_sessionfinish(None, 0)
+    my_plugin._add_results(testrun_id=10, results=results)
 
-    api_client.send_get.assert_called_once_with(vars.GET_TESTS_URL.format(my_plugin.testrun_id),
-                                                cert_check=True)
-    expected_uri = vars.ADD_RESULTS_URL.format(my_plugin.testrun_id)
-    expected_data = {
-        'results': [
-            {
-                'case_id': 1234,
-                'status_id': TESTRAIL_TEST_STATUS["blocked"],
-                'version': '1.0.0.0'
-            }
-        ]}
-    assert len(api_client.send_post.call_args_list) == 1
-    assert api_client.send_post.call_args_list[0] == call(expected_uri, expected_data, cert_check=True)
+    api_client.send_get.assert_called_once_with(vars.GET_TESTS_URL.format(10), cert_check=True)
+
+    # case 1234 is blocked in TR → filtered out; only case 5678 (passed) is published
+    expected_uri = vars.ADD_RESULTS_URL.format(10)
+    expected_data = {'results': [{
+        'case_id': 5678,
+        'status_id': TESTRAIL_TEST_STATUS["passed"],
+        'defects': None,
+        'version': '1.0.0.0',
+        'comment': '',
+    }]}
+    api_client.send_post.assert_called_once_with(expected_uri, expected_data, cert_check=True)
 
 
 def test_skip_missing_only_one_test(api_client, pytest_test_items):
@@ -408,10 +384,13 @@ def test_skip_missing_only_one_test(api_client, pytest_test_items):
                                  publish_blocked=False,
                                  skip_missing=True)
 
-    api_client.send_get.return_value = [
-        {"case_id": 1234}, {"case_id": 5678}
+    api_client.send_get.side_effect = [
+        [{'id': SUITE_ID, 'name': 'Suite 1'}],                           # get_suites
+        [{'id': 1234}, {'id': 5678}],                                     # get_cases
+        {'plan_id': None, 'suite_id': SUITE_ID, 'is_completed': False},   # get_run
+        [],                                                                # get_tests (update_testrun)
     ]
-    my_plugin.is_testrun_available = lambda: True
+    api_client.send_post.return_value = {'id': 10}
 
     my_plugin.pytest_collection_modifyitems(None, None, pytest_test_items)
 
@@ -427,10 +406,14 @@ def test_skip_missing_correlation_tests(api_client, pytest_test_items):
                                  publish_blocked=False,
                                  skip_missing=True)
 
-    api_client.send_get.return_value = [
-        {"case_id": 1234}, {"case_id": 8765}
+    # Each test function has one case in TR and one not — neither should be skipped
+    api_client.send_get.side_effect = [
+        [{'id': SUITE_ID, 'name': 'Suite 1'}],                           # get_suites
+        [{'id': 1234}, {'id': 8765}],                                     # get_cases: one from each test
+        {'plan_id': None, 'suite_id': SUITE_ID, 'is_completed': False},   # get_run
+        [],                                                                # get_tests (update_testrun)
     ]
-    my_plugin.is_testrun_available = lambda: True
+    api_client.send_post.return_value = {'id': 10}
 
     my_plugin.pytest_collection_modifyitems(None, None, pytest_test_items)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,10 +1,12 @@
 # -*- coding: UTF-8 -*-
+import json
 from datetime import datetime
+from types import SimpleNamespace
 from freezegun import freeze_time
-from mock import call, create_autospec, MagicMock
+from mock import create_autospec, MagicMock
 import pytest
 from pytest_testrail import vars, plugin
-from pytest_testrail.plugin import PyTestRailPlugin
+from pytest_testrail.plugin import PyTestRailPlugin, NodeAction
 from pytest_testrail.testrail_api import APIClient
 from pytest_testrail.vars import TESTRAIL_TEST_STATUS
 
@@ -441,3 +443,166 @@ def test_api_client_timeout(api_client):
 
     api_client.send_post('/timeout', data={"body": "body"}, timeout=None)
     api_client.send_post.assert_called_with('/timeout', data={"body": "body"}, timeout=None)
+
+
+# ──────────────────────────── xdist tests ────────────────────────────
+
+def _drive_sessionfinish_hook(tr_plugin, session):
+    """Drive the pytest_sessionfinish hookwrapper generator to completion."""
+    gen = tr_plugin.pytest_sessionfinish(session, 0)
+    next(gen)
+    try:
+        gen.send(None)
+    except StopIteration:
+        pass
+
+
+def test_xdist_worker_saves_results_to_workeroutput(tr_plugin):
+    """xdist worker must store results in workeroutput, not call publish_results."""
+    worker_results = [
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'suite_id': SUITE_ID,
+         'comment': '', 'duration': 1, 'defects': None, 'test_parametrize': None, 'test_comments': []},
+    ]
+    tr_plugin.testrail_data.results = worker_results
+
+    session = MagicMock()
+    # Presence of workerinput marks this as an xdist worker
+    session.config.workerinput = {}
+    session.config.workeroutput = {}
+
+    _drive_sessionfinish_hook(tr_plugin, session)
+
+    assert session.config.workeroutput['testrail_results'] == worker_results
+    # publish_results makes API calls; none should happen on a worker
+    tr_plugin.testrail_data.client.send_post.assert_not_called()
+
+
+def test_xdist_controller_publishes_results(api_client, tr_plugin):
+    """xdist controller (no workerinput) must publish all collected results."""
+    tr_plugin.testrail_data.results = [
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'suite_id': SUITE_ID,
+         'comment': '', 'duration': 1, 'defects': None, 'test_parametrize': None, 'test_comments': []},
+    ]
+    tr_plugin.testrail_data.testrun_id = 10
+    tr_plugin.testrail_data.diff_case_ids = []
+    tr_plugin.testrail_data.plan_entry_storage = {
+        SUITE_ID: {'testrun_id': 10, 'testplan_entry_id': None, 'case_ids': [1234]}
+    }
+    api_client.send_post.return_value = {}
+
+    # Controller: config has NO workerinput attribute
+    config = SimpleNamespace()
+    session = MagicMock()
+    session.config = config
+
+    _drive_sessionfinish_hook(tr_plugin, session)
+
+    api_client.send_post.assert_called_once_with(
+        vars.ADD_RESULTS_URL.format(10),
+        {'results': [{
+            'case_id': 1234,
+            'status_id': TESTRAIL_TEST_STATUS["passed"],
+            'defects': None,
+            'version': '1.0.0.0',
+            'elapsed': '1s',
+            'comment': '{}\n'.format(CUSTOM_COMMENT),
+        }]},
+        cert_check=True,
+    )
+
+
+def test_xdist_node_action_configure_node(tr_plugin):
+    """NodeAction must pass testrun_id and actual_suites_with_case_ids to workers."""
+    tr_plugin.testrail_data.testrun_id = 42
+    tr_plugin.testrail_data.actual_suites_with_case_ids = {SUITE_ID: [1234, 5678]}
+
+    node_action = NodeAction(tr_plugin.testrail_data)
+    node = MagicMock()
+    node.workerinput = {}
+
+    node_action.pytest_configure_node(node)
+
+    assert node.workerinput['test_run_id'] == 42
+    suites = json.loads(node.workerinput['actual_suites_with_case_ids'])
+    assert suites == {str(SUITE_ID): [1234, 5678]}
+
+
+def test_xdist_node_action_collects_worker_results(tr_plugin):
+    """pytest_testnodedown must aggregate results from each finished worker."""
+    node_action = NodeAction(tr_plugin.testrail_data)
+
+    worker1_results = [
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'suite_id': SUITE_ID},
+    ]
+    worker2_results = [
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'suite_id': SUITE_ID},
+    ]
+
+    node1, node2 = MagicMock(), MagicMock()
+    node1.workeroutput = {'testrail_results': worker1_results}
+    node2.workeroutput = {'testrail_results': worker2_results}
+
+    node_action.pytest_testnodedown(node1, None)
+    node_action.pytest_testnodedown(node2, None)
+
+    assert tr_plugin.testrail_data.results == worker1_results + worker2_results
+
+
+def test_xdist_worker_sessionstart_loads_suites(tr_plugin):
+    """xdist worker must load actual_suites_with_case_ids from workerinput."""
+    suites = {SUITE_ID: [1234, 5678]}
+
+    session = MagicMock()
+    session.config.workerinput = {
+        'test_run_id': 99,
+        'actual_suites_with_case_ids': json.dumps({str(k): v for k, v in suites.items()}),
+    }
+
+    tr_plugin.pytest_sessionstart(session)
+
+    assert tr_plugin.testrail_data.testrun_id == 99
+    assert tr_plugin.testrail_data.actual_suites_with_case_ids == suites
+
+
+def test_xdist_full_flow_publishes_once(api_client, tr_plugin):
+    """Full xdist flow: two workers finish → results aggregated → published once."""
+    node_action = NodeAction(tr_plugin.testrail_data)
+
+    worker1_results = [
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'suite_id': SUITE_ID,
+         'comment': '', 'duration': 1, 'defects': None, 'test_parametrize': None, 'test_comments': []},
+    ]
+    worker2_results = [
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'suite_id': SUITE_ID,
+         'comment': 'err', 'duration': 2, 'defects': None, 'test_parametrize': None, 'test_comments': []},
+    ]
+
+    node1, node2 = MagicMock(), MagicMock()
+    node1.workeroutput = {'testrail_results': worker1_results}
+    node2.workeroutput = {'testrail_results': worker2_results}
+
+    # Workers finish → NodeAction collects their results
+    node_action.pytest_testnodedown(node1, None)
+    node_action.pytest_testnodedown(node2, None)
+
+    assert len(tr_plugin.testrail_data.results) == 2
+
+    # Controller publishes once
+    tr_plugin.testrail_data.testrun_id = 10
+    tr_plugin.testrail_data.diff_case_ids = []
+    tr_plugin.testrail_data.plan_entry_storage = {
+        SUITE_ID: {'testrun_id': 10, 'testplan_entry_id': None, 'case_ids': [1234, 5678]}
+    }
+    api_client.send_post.return_value = {}
+
+    config = SimpleNamespace()
+    session = MagicMock()
+    session.config = config
+
+    _drive_sessionfinish_hook(tr_plugin, session)
+
+    # publish_results must be called exactly once (one API call for this chunk)
+    assert api_client.send_post.call_count == 1
+    call_args = api_client.send_post.call_args
+    published_case_ids = {r['case_id'] for r in call_args[0][1]['results']}
+    assert published_case_ids == {1234, 5678}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -170,7 +170,7 @@ def test_pytest_sessionfinish(api_client, tr_plugin):
     }
     api_client.send_post.return_value = {}
 
-    tr_plugin.publish_results(testrail_data=tr_plugin.testrail_data, results=tr_plugin.testrail_data.results)
+    tr_plugin.publish_results(results=tr_plugin.testrail_data.results)
 
     expected_data = {'results': [
         {
@@ -219,7 +219,7 @@ def test_pytest_sessionfinish_testplan(api_client, tr_plugin):
     }
     api_client.send_post.return_value = {}
 
-    tr_plugin.publish_results(testrail_data=tr_plugin.testrail_data, results=tr_plugin.testrail_data.results)
+    tr_plugin.publish_results(results=tr_plugin.testrail_data.results)
 
     expected_data_59 = {'results': [{
         'case_id': 1234,
@@ -316,7 +316,7 @@ def test_close_test_run(api_client, tr_plugin):
     }
     api_client.send_post.return_value = {}
 
-    tr_plugin.publish_results(testrail_data=tr_plugin.testrail_data, results=tr_plugin.testrail_data.results)
+    tr_plugin.publish_results(results=tr_plugin.testrail_data.results)
 
     api_client.send_post.assert_any_call(vars.CLOSE_TESTRUN_URL.format(10), data={}, cert_check=True)
 
@@ -337,7 +337,7 @@ def test_close_test_plan(api_client, tr_plugin):
     }
     api_client.send_post.return_value = {}
 
-    tr_plugin.publish_results(testrail_data=tr_plugin.testrail_data, results=tr_plugin.testrail_data.results)
+    tr_plugin.publish_results(results=tr_plugin.testrail_data.results)
 
     api_client.send_post.assert_any_call(vars.CLOSE_TESTPLAN_URL.format(100), data={}, cert_check=True)
 


### PR DESCRIPTION
This pull request introduces several improvements and code modernizations to the pytest-testrail plugin, focusing on type safety, Python 3 compatibility, and configuration handling. The changes update type annotations, improve the use of dataclasses, clean up imports, and refactor configuration management for better readability and maintainability.

Key improvements include:

**Type Annotations and Dataclass Improvements:**

* Updated the `TestRailModel` dataclass to use explicit type annotations (including `| None` for optional types), replaced mutable default arguments with `field(default_factory=...)`, and imported `Any` for better type safety.

**Configuration and Compatibility Refactoring:**

* Removed legacy Python 2 compatibility code from `conftest.py`, standardized on Python 3 imports, and refactored the `pytest_addoption` and `pytest_configure` functions for clarity and consistency.
* Improved the `ConfigManager` logic for retrieving configuration options, making the code more readable and robust by using multi-line expressions and clearer boolean handling. [[1]](diffhunk://#diff-5e48c5b9b8d78cb7737c901f7c7ac27a15ff156d728b737761ac8fcd74c2d6a0L197-R319) [[2]](diffhunk://#diff-5e48c5b9b8d78cb7737c901f7c7ac27a15ff156d728b737761ac8fcd74c2d6a0L207-R333)

**Code Style and Import Cleanup:**

* Cleaned up imports and standardized aliasing in `__init__.py`.
* Updated the version number in `.bumpversion.cfg` to `3.0.7`.

These changes collectively modernize the codebase, improve maintainability, and ensure better type safety and configuration handling.